### PR TITLE
[CB-166] 빌드에러 수정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext", "ES2021"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "es2022",
+    "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -20,6 +20,7 @@
       "@/*": ["./src/*"]
     }
   },
+  "buildOptions": { "target": "esnext", "module": "esnext", "moduleResolution": "Node" },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,18 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig } from 'vite';
-import EnvironmentPlugin from 'vite-plugin-environment';
 import react from '@vitejs/plugin-react';
 import * as path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), EnvironmentPlugin('all')],
+  plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+  },
+  define: {
+    'process.env.VITE_API_BASE_URL': JSON.stringify(process.env.VITE_API_BASE_URL),
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
   },
 });


### PR DESCRIPTION
[CB-166]

### 🔨 Jira 태스크

- CB-166

### 📐 구현한 내용

- import.meta.env가 빌드 시에 에러를 발생시키는 문제 해결
- build option을 수정해도 해결되지 않아 vite.config.ts에서 process.env로 매칭을 시킴

### 🚧 논의 사항

- import.meta.env가 아닌 process.env로 사용해도 됩니다. 단, 새로운 변수 추가시에는 vite.config.ts 파일에 명시해주시기 바랍니다.


[CB-166]: https://cocobob.atlassian.net/browse/CB-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ