### PR TITLE
[Hotfix] uuid와 Jest 버전 호환 불가로 인한 테스트 에러 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "@mui/material": "^5.9.1",
                 "@mui/styled-engine-sc": "^5.8.0",
                 "@reduxjs/toolkit": "^1.8.3",
-                "@types/uuid": "^8.3.4",
                 "autoprefixer": "^10.4.7",
                 "axios": "^0.27.2",
                 "dayjs": "^1.11.4",
@@ -32,7 +31,7 @@
                 "styled-components": "^5.3.5",
                 "tailwindcss": "^3.1.5",
                 "ts-node": "^10.8.2",
-                "uuid": "^8.3.2",
+                "uuid": "8.1.0",
                 "vite-plugin-svgr": "^2.2.1"
             },
             "devDependencies": {
@@ -56,6 +55,7 @@
                 "@types/react-helmet": "^6.1.5",
                 "@types/react-transition-group": "^4.4.5",
                 "@types/styled-components": "^5.1.25",
+                "@types/uuid": "^8.3.4",
                 "@typescript-eslint/eslint-plugin": "^5.30.5",
                 "@typescript-eslint/parser": "^5.30.5",
                 "@vitejs/plugin-react": "^1.3.0",
@@ -7870,7 +7870,8 @@
         "node_modules/@types/uuid": {
             "version": "8.3.4",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "node_modules/@types/webpack": {
             "version": "4.41.32",
@@ -26667,9 +26668,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+            "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -33524,7 +33525,8 @@
         "@types/uuid": {
             "version": "8.3.4",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "@types/webpack": {
             "version": "4.41.32",
@@ -47698,9 +47700,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+            "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
         },
         "uuid-browser": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
         "@mui/material": "^5.9.1",
         "@mui/styled-engine-sc": "^5.8.0",
         "@reduxjs/toolkit": "^1.8.3",
-        "@types/uuid": "^8.3.4",
         "autoprefixer": "^10.4.7",
         "axios": "^0.27.2",
         "dayjs": "^1.11.4",
@@ -44,8 +43,8 @@
         "styled-components": "^5.3.5",
         "tailwindcss": "^3.1.5",
         "ts-node": "^10.8.2",
-        "vite-plugin-svgr": "^2.2.1",
-        "uuid": "^8.3.2"
+        "uuid": "8.1.0",
+        "vite-plugin-svgr": "^2.2.1"
     },
     "devDependencies": {
         "@babel/core": "^7.18.6",
@@ -68,6 +67,7 @@
         "@types/react-helmet": "^6.1.5",
         "@types/react-transition-group": "^4.4.5",
         "@types/styled-components": "^5.1.25",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "@vitejs/plugin-react": "^1.3.0",


### PR DESCRIPTION
### 🔨 Jira 태스크

-

### 📐 구현한 내용

- uuid 최신 버전이 Jest와 호환되지 않아 버전 다운
  - 8.3.2 =>8.1.0

### 🚧 논의 사항

-
