### PR TITLE
[CB-171] 테마 스타일 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # CocoBob-FE
+
+### zIndex
+
+- 9999 : ToastMessage, ToastConfirm, ToastConfirmBackground
+- 1000 : Layout Header, Layout Footer
+-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,14 @@ import LoginPage from '@/pages/Login';
 import PrivateRoutes from './routes/PrivateRoutes';
 import PageTransition from './components/transition/PageTransition';
 import ToastMessage from './components/Toast/ToastMessage';
+import ToastConfirm from './components/Toast/ToastConfirm';
 
 function App() {
   const location = useLocation();
   return (
     <PageTransition transitionKey={location.pathname}>
       <ToastMessage />
+      <ToastConfirm />
       <Routes key={location.pathname} location={location}>
         <Route element={<PrivateRoutes />} path="/*" />
         <Route element={<LoginPage />} path="/login" />

--- a/src/components/Form/FormInput.tsx
+++ b/src/components/Form/FormInput.tsx
@@ -23,7 +23,7 @@ export const Label = styled.label<{ isError: boolean | undefined }>`
   font-size: 14px;
   line-height: 20px;
   font-weight: 500;
-  color: ${({ isError }) => (isError ? '#E85354' : '#1d1d1d')};
+  color: ${({ isError, theme: { colors } }) => (isError ? colors.error : '#1d1d1d')};
 `;
 const InputWrapper = styled.div`
   display: flex;
@@ -41,7 +41,7 @@ export const InputStyle = styled.input<{ isError: boolean | undefined }>`
   height: 46px;
   padding: 0 0.5rem;
   background: #fffdfd;
-  border: 1px solid ${({ isError }) => (isError ? '#E85354' : '#EDEDED')};
+  border: 1px solid ${({ isError, theme: { colors } }) => (isError ? colors.error : '#EDEDED')};
   border-radius: 10px;
 
   ::placeholder {

--- a/src/components/Toast/ToastConfirm.tsx
+++ b/src/components/Toast/ToastConfirm.tsx
@@ -1,0 +1,60 @@
+import { RootState, useAppDispatch, useAppSelector } from '@/store/config';
+import { closeConfirmAction, executeConfirmCallbackAction } from '@/store/slices/toastSlice';
+
+import styled from 'styled-components';
+
+const ToastMessageItem = styled.div`
+  position: fixed;
+  z-index: 9999;
+  left: 0;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  margin: auto;
+  width: 358px;
+  height: 145px;
+  background: #ffffff;
+  /* Shadow/default */
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.15);
+  border-radius: 10px;
+
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  justify-content: space-around;
+  align-items: center;
+  h3 {
+    text-align: center;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 46px;
+    letter-spacing: -0.02em;
+    text-align: center;
+    color: ${({ theme: { colors } }) => colors.primary.bright};
+  }
+`;
+export default function ToastConfirm() {
+  const dispatch = useAppDispatch();
+  const { confirmMessage } = useAppSelector((state: RootState) => state.toast);
+
+  const closeConfirm = () => dispatch(closeConfirmAction());
+  const submitConfirm = () => dispatch(executeConfirmCallbackAction());
+
+  return (
+    <>
+      {confirmMessage !== '' && (
+        <ToastMessageItem>
+          <h3>{confirmMessage}</h3>
+          <div className="flex gap-4">
+            <button type="button" onClick={closeConfirm}>
+              취소
+            </button>
+            <button type="button" onClick={submitConfirm}>
+              확인
+            </button>
+          </div>
+        </ToastMessageItem>
+      )}
+    </>
+  );
+}

--- a/src/components/Toast/ToastConfirm.tsx
+++ b/src/components/Toast/ToastConfirm.tsx
@@ -3,6 +3,13 @@ import { closeConfirmAction, executeConfirmCallbackAction } from '@/store/slices
 
 import styled from 'styled-components';
 
+const Background = styled.div`
+  z-index: 9999;
+  position: fixed;
+  background: rgb(0, 0, 0, 0.5);
+  width: 100%;
+  height: 100%;
+`;
 const ToastMessageItem = styled.div`
   position: fixed;
   z-index: 9999;
@@ -11,7 +18,7 @@ const ToastMessageItem = styled.div`
   top: 50%;
   transform: translateY(-50%);
   margin: auto;
-  width: 358px;
+  width: 330px;
   height: 145px;
   background: #ffffff;
   /* Shadow/default */
@@ -26,12 +33,26 @@ const ToastMessageItem = styled.div`
   h3 {
     text-align: center;
     font-weight: 500;
-    font-size: 13px;
+    font-size: 15px;
     line-height: 46px;
     letter-spacing: -0.02em;
     text-align: center;
     color: ${({ theme: { colors } }) => colors.primary.bright};
   }
+`;
+const ToastConfirmButton = styled.button`
+  text-align: center;
+  font-size: 0.875rem;
+  padding: 0.25rem 1.25rem;
+`;
+const CancelButton = styled(ToastConfirmButton)`
+  border-radius: 10px;
+  border: 1px solid ${({ theme: { colors } }) => colors.text.caption};
+`;
+const ConfirmButton = styled(ToastConfirmButton)`
+  background: ${({ theme: { colors } }) => colors.success};
+  border-radius: 10px;
+  color: #fff;
 `;
 export default function ToastConfirm() {
   const dispatch = useAppDispatch();
@@ -43,17 +64,19 @@ export default function ToastConfirm() {
   return (
     <>
       {confirmMessage !== '' && (
-        <ToastMessageItem>
-          <h3>{confirmMessage}</h3>
-          <div className="flex gap-4">
-            <button type="button" onClick={closeConfirm}>
-              취소
-            </button>
-            <button type="button" onClick={submitConfirm}>
-              확인
-            </button>
-          </div>
-        </ToastMessageItem>
+        <Background>
+          <ToastMessageItem>
+            <h3>{confirmMessage}</h3>
+            <div className="flex gap-4">
+              <CancelButton type="button" onClick={closeConfirm}>
+                취소
+              </CancelButton>
+              <ConfirmButton type="button" onClick={submitConfirm}>
+                확인
+              </ConfirmButton>
+            </div>
+          </ToastMessageItem>
+        </Background>
       )}
     </>
   );

--- a/src/components/Toast/ToastMessage.tsx
+++ b/src/components/Toast/ToastMessage.tsx
@@ -31,14 +31,17 @@ const Container = styled.div`
     }
   }
 `;
-const ToastMessageItem = styled.div`
+const ToastMessageItem = styled.div<{ type: 'success' | 'error' }>`
   position: fixed;
+  z-index: 9999;
   left: 0;
   right: 0;
+  top: 16px;
   margin: auto;
   width: 358px;
   height: 46px;
-  background: #e85354;
+  background: ${({ type, theme: { colors } }) =>
+    type === 'error' ? colors.error : colors.success};
   /* Shadow/default */
   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.15);
   border-radius: 10px;
@@ -55,7 +58,7 @@ const ToastMessageItem = styled.div`
 export default function ToastMessage() {
   const [animationName, setAnimationName] = useState<string>('fade-in');
   const toastMessage = useSelector(getToast);
-  const { id, content, time } = toastMessage;
+  const { id, content, time, type } = toastMessage;
   const dispatch = useDispatch();
   const timeoutId = useRef<null | ReturnType<typeof setTimeout>>(null);
   const removeToast = () => {
@@ -76,7 +79,7 @@ export default function ToastMessage() {
   return (
     <Container>
       {content !== '' && (
-        <ToastMessageItem onClick={removeToast} className={animationName}>
+        <ToastMessageItem onClick={removeToast} className={animationName} type={type}>
           <h3>{content}</h3>
         </ToastMessageItem>
       )}

--- a/src/components/layout/Footer.style.ts
+++ b/src/components/layout/Footer.style.ts
@@ -12,7 +12,7 @@ export const NavBar = styled.nav`
   display: flex;
   justify-content: space-between;
   box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.05);
-  z-index: 9999;
+  z-index: 1000;
   @media (min-width: 425px) {
     width: 425px;
   }

--- a/src/components/layout/Header.style.ts
+++ b/src/components/layout/Header.style.ts
@@ -9,7 +9,7 @@ export const HeaderWrapper = styled.header`
   left: 0;
   color: #222;
   background: white;
-  z-index: 9999;
+  z-index: 1000;
 `;
 export const HeaderContents = styled.div`
   display: flex;

--- a/src/pages/Login/components/SignUpForm.tsx
+++ b/src/pages/Login/components/SignUpForm.tsx
@@ -6,6 +6,7 @@ import FormInput from '@/components/Form/FormInput';
 import { useSignUpMutation } from '@/store/api/userApi';
 import useBottomSheet from '@/utils/hooks/useBottomSheet';
 
+import useToastMessage from '@/utils/hooks/useToastMessage';
 import { checkEmailDuplicated } from '../api';
 import {
   CheckEmailButton,
@@ -19,7 +20,7 @@ import { ISignUpForm } from '../types';
 
 export default function SignUpForm({ isOpen }: { isOpen: boolean }) {
   const { openBottomSheet: openEmailLoginBottomSheet } = useBottomSheet('emailLogin');
-
+  const openToast = useToastMessage();
   const {
     register,
     handleSubmit,
@@ -40,7 +41,7 @@ export default function SignUpForm({ isOpen }: { isOpen: boolean }) {
 
   const onClickSignUp = async (data: ISignUpForm) => {
     if (!emailChecked || data.email !== emailChecked) {
-      alert('이메일 중복체크가 필요합니다.');
+      openToast('이메일 중복체크가 필요합니다.');
       return;
     }
     await signUp(data);
@@ -56,7 +57,7 @@ export default function SignUpForm({ isOpen }: { isOpen: boolean }) {
 
     const fetchResult = await checkEmailDuplicated(emailValue);
     if (!fetchResult) {
-      alert('에러가 발생하였습니다.');
+      openToast('에러가 발생하였습니다.');
       return;
     }
 

--- a/src/pages/Mypage/pets/[id].tsx
+++ b/src/pages/Mypage/pets/[id].tsx
@@ -25,6 +25,8 @@ import { ReactComponent as CalendarIcon } from '@/assets/icon/calendar_icon.svg'
 import PetDefault from '@/assets/image/pet_default.png';
 import { RegisterInfoForm } from '@/store/slices/registerPetSlice';
 import { getFileFromObjectURL } from '@/utils/libs/getFileFromObjectURL';
+import useToastMessage from '@/utils/hooks/useToastMessage';
+import useToastConfirm from '@/utils/hooks/useToastConfirm';
 import {
   AgeDescription,
   AgeSelectButton,
@@ -64,6 +66,7 @@ export default function PetDetail() {
   const { imageFile, previewUrl, handleChangeImage, setPreviewUrl } = useSelectImage({
     initPreviewUrl: petData?.thumbnailPath,
   });
+  const openToast = useToastMessage();
   const { openBottomSheet: openBreedBottomSheet, isBottomSheetOpen: isBreedBottomSheetOpen } =
     useBottomSheet('findBreed');
   const {
@@ -81,13 +84,17 @@ export default function PetDetail() {
   const [breed, setBreed] = useState<IBreeds | undefined>();
   const [isImageDeleted, setIsImageDeleted] = useState(false); // 사진을 삭제했을 때 true, 변경하거나 그대로 유지 : false
 
-  const deleteProfileImage = () => {
-    // eslint-disable-next-line no-alert, no-restricted-globals
-    if (previewUrl && confirm('프로필 사진을 삭제하시겠습니까?')) {
-      setPreviewUrl('');
-      setIsImageDeleted(true);
-    }
+  const initProfileImage = () => {
+    setPreviewUrl('');
+    setIsImageDeleted(true);
   };
+  const confirmDeleteProfile = useToastConfirm(initProfileImage);
+
+  const deleteProfileImage = () => {
+    if (!previewUrl) return;
+    confirmDeleteProfile('프로필 사진을 삭제하시겠습니까?');
+  };
+
   const onSubmit = async (data: IPetEditForm) => {
     if ((!months && !birthday) || !breed?.id) return;
     const updateParams = {
@@ -123,15 +130,17 @@ export default function PetDetail() {
       initForm(petData);
     }
   }, [petData]);
+
   useEffect(() => {
     if (imageFile) {
       setIsImageDeleted(false);
     }
   }, [imageFile]);
+
   useEffect(() => {
     if (!mutationResult) return;
     navigate('/mypage/pets');
-    alert('성공적으로 정보를 수정하였습니다.');
+    openToast('성공적으로 정보를 수정하였습니다.', 'success');
   }, [mutationResult]);
 
   return (

--- a/src/pages/RegisterPet/Step3.tsx
+++ b/src/pages/RegisterPet/Step3.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 
 import { useForm } from 'react-hook-form';
 import useSearchBreed from '@/utils/hooks/useSearchBreed';
+import useToastMessage from '@/utils/hooks/useToastMessage';
 import { ButtonWrapper, Form, PageContainer, PetNameHighlight, QuestionText } from './index.style';
 
 interface IBreedList {
@@ -91,7 +92,7 @@ export const SearchBreedBottomSheet = ({
 
 export default function Step3({ goNextStep }: any) {
   const { isBottomSheetOpen, openBottomSheet, closeBottomSheet } = useBottomSheet('findBreed');
-
+  const openToast = useToastMessage();
   const { isSuccess, data: breeds } = useGetBreedsQuery();
   const [breed, setBreed] = useState<IBreeds | undefined>();
 
@@ -101,7 +102,7 @@ export default function Step3({ goNextStep }: any) {
 
   const onValidSubmit = () => {
     if (!breed) {
-      alert('견종을 선택해주세요');
+      openToast('견종을 선택해주세요');
       return;
     }
     dispatch(

--- a/src/pages/RegisterPet/Step4.tsx
+++ b/src/pages/RegisterPet/Step4.tsx
@@ -12,6 +12,7 @@ import {
   getTotalMonthWithYearAndMonth,
 } from '@/utils/libs/date';
 import useBottomSheet from '@/utils/hooks/useBottomSheet';
+import useToastMessage from '@/utils/hooks/useToastMessage';
 import { ButtonWrapper, PageContainer, QuestionText, Form, PetNameHighlight } from './index.style';
 import { IPrevNextStep } from './type';
 
@@ -32,7 +33,7 @@ export default function Step4({ goNextStep }: IPrevNextStep) {
     isBottomSheetOpen: isMonthsAgeBottomSheetOpen,
     openBottomSheet: openMonthsAgeBottomSheet,
   } = useBottomSheet('monthsAge');
-
+  const openToast = useToastMessage();
   const dispatch = useDispatch();
   const registerInfo = useSelector(selectRegisterInfo);
 
@@ -77,7 +78,7 @@ export default function Step4({ goNextStep }: IPrevNextStep) {
 
   const onValidSubmit = () => {
     if (!age.birthday && !age.months) {
-      alert('나이를 입력해주세요');
+      openToast('나이를 입력해주세요');
       return;
     }
     saveAgeInStore();

--- a/src/pages/RegisterPet/index.tsx
+++ b/src/pages/RegisterPet/index.tsx
@@ -7,6 +7,7 @@ import { RootState, useAppDispatch, useAppSelector } from '@/store/config';
 import { useSaveEnrollmentDataMutation } from '@/store/api/petApi';
 import { clearRegisterInfo } from '@/store/slices/registerPetSlice';
 import { getFileFromObjectURL } from '@/utils/libs/getFileFromObjectURL';
+import useToastMessage from '@/utils/hooks/useToastMessage';
 import Step1 from './Step1';
 import Step2 from './Step2';
 import Step3 from './Step3';
@@ -22,6 +23,7 @@ export default function RegisterPet() {
   );
   const [currentStep, setCurrentStep] = useState(1);
   const [enrollPetMutation, { isError, isSuccess }] = useSaveEnrollmentDataMutation();
+  const openToast = useToastMessage();
 
   const goNextStep = async () => {
     setCurrentStep((step) => step + 1);
@@ -67,7 +69,7 @@ export default function RegisterPet() {
 
   useEffect(() => {
     if (!isError) return;
-    alert('등록에 실패하였습니다.');
+    openToast('등록에 실패하였습니다.');
     setCurrentStep((step) => step - 1);
   }, [isError]);
 

--- a/src/store/slices/apiSlice.ts
+++ b/src/store/slices/apiSlice.ts
@@ -59,7 +59,6 @@ const baseQueryWithReAuth = async (
     const { data, error } = await refreshQuery('/users/token', api, extraOptions);
     if (!data || error?.status === 401 || (data && (data as IGenericResponse).status === 401)) {
       // error occured
-      alert('로그인이 필요합니다.');
       api.dispatch(logout());
     } else if (data && (data as IGenericResponse).status === 202) {
       // store new token

--- a/src/store/slices/toastSlice.ts
+++ b/src/store/slices/toastSlice.ts
@@ -2,16 +2,28 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../config';
 // eslint-disable-next-line import/no-cycle
 
+export type ToastMessageType = 'error' | 'success';
+
 export type ToastState = {
   id: string;
   content: string;
   time: number;
+  type: ToastMessageType;
+};
+export type ToastConfirmState = {
+  confirmMessage: string;
+  executeCallback: boolean;
 };
 
-const initialState: ToastState = {
+interface IToastSlice extends ToastState, ToastConfirmState {}
+
+const initialState: IToastSlice = {
   id: '',
   content: '',
   time: 3000,
+  type: 'error',
+  confirmMessage: '',
+  executeCallback: false,
 };
 const toastSlice = createSlice({
   name: 'toast',
@@ -21,13 +33,30 @@ const toastSlice = createSlice({
       state.id = payload.id;
       state.content = payload.content;
       state.time = payload.time ?? 3000;
+      state.type = payload.type ?? 'error';
     },
     deleteToastAction: (state) => {
       state.content = '';
+    },
+    addConfirmAction: (state, { payload }: PayloadAction<{ confirmMessage: string }>) => {
+      state.confirmMessage = payload.confirmMessage;
+    },
+    executeConfirmCallbackAction: (state) => {
+      state.executeCallback = true;
+    },
+    closeConfirmAction: (state) => {
+      state.confirmMessage = '';
+      state.executeCallback = false;
     },
   },
 });
 
 export const getToast = (state: RootState) => state.toast;
-export const { addToastAction, deleteToastAction } = toastSlice.actions;
+export const {
+  addToastAction,
+  deleteToastAction,
+  addConfirmAction,
+  closeConfirmAction,
+  executeConfirmCallbackAction,
+} = toastSlice.actions;
 export default toastSlice.reducer;

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,0 +1,25 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    colors: {
+      primary: {
+        dark: string;
+        main: string;
+        bright: string;
+        light: string;
+      };
+      secondary: {
+        main: string;
+        light: string;
+      };
+      text: {
+        title: string;
+        default: string;
+        caption: string;
+      };
+      error: string;
+      success: string;
+    };
+  }
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,4 +1,6 @@
-export const theme = {
+import { DefaultTheme } from 'styled-components';
+
+export const theme: DefaultTheme = {
   colors: {
     primary: {
       dark: '#114786',
@@ -15,5 +17,7 @@ export const theme = {
       default: '#333333',
       caption: '#999999',
     },
+    error: '#e85354',
+    success: '#3abb67',
   },
 };

--- a/src/utils/hooks/useLogout.tsx
+++ b/src/utils/hooks/useLogout.tsx
@@ -3,11 +3,13 @@ import { useAppDispatch } from '@/store/config';
 import { logout } from '@/store/slices/authSlice';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import useToastConfirm from './useToastConfirm';
 
 export default function useLogout() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const [logoutMutation, { isSuccess }] = useLogoutMutation();
+  const logoutConfirm = useToastConfirm(() => logoutMutation());
 
   useEffect(() => {
     if (isSuccess) {
@@ -17,10 +19,7 @@ export default function useLogout() {
   }, [isSuccess]);
 
   const onClickLogout = () => {
-    // eslint-disable-next-line no-restricted-globals
-    if (confirm('로그아웃을 하시겠습니까?')) {
-      logoutMutation();
-    }
+    logoutConfirm('로그아웃을 하시겠습니까?');
   };
   return onClickLogout;
 }

--- a/src/utils/hooks/useSelectImage.tsx
+++ b/src/utils/hooks/useSelectImage.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useState } from 'react';
+import useToastMessage from './useToastMessage';
 
 export default function useSelectImage({
   initPreviewUrl,
@@ -9,6 +10,7 @@ export default function useSelectImage({
 }) {
   const [previewUrl, setPreviewUrl] = useState(initPreviewUrl);
   const [imageFile, setImageFile] = useState<string | undefined>(initImageFile);
+  const openToast = useToastMessage();
 
   const handleChangeImage = (event: ChangeEvent<HTMLInputElement>) => {
     const {
@@ -18,7 +20,7 @@ export default function useSelectImage({
 
     const image = files[0];
     if (!image.type.includes('image/')) {
-      alert('사진을 선택해주세요.');
+      openToast('사진을 선택해주세요.');
       return;
     }
     setImageFile(URL.createObjectURL(image));

--- a/src/utils/hooks/useToastConfirm.tsx
+++ b/src/utils/hooks/useToastConfirm.tsx
@@ -1,0 +1,21 @@
+import { useAppSelector } from '@/store/config';
+import { addConfirmAction, closeConfirmAction, getToast } from '@/store/slices/toastSlice';
+import { useCallback, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+export default function useToastConfirm(callback = () => {}) {
+  const dispatch = useDispatch();
+  const { executeCallback } = useAppSelector(getToast);
+
+  const openConfirm = useCallback((confirmMessage: string) => {
+    dispatch(addConfirmAction({ confirmMessage }));
+  }, []);
+
+  useEffect(() => {
+    if (!executeCallback) return;
+    callback();
+    dispatch(closeConfirmAction());
+  }, [executeCallback]);
+
+  return openConfirm;
+}

--- a/src/utils/hooks/useToastMessage.tsx
+++ b/src/utils/hooks/useToastMessage.tsx
@@ -9,8 +9,10 @@ interface ToastProps {
 
 export default function useToastMessage(option?: ToastProps) {
   const dispatch = useDispatch();
-  const openToast = useCallback((content: string) => {
-    dispatch(addToastAction({ id: uuidv4(), content, time: option?.time ?? 3000 }));
+  const openToast = useCallback((content: string, type?: 'success' | 'error') => {
+    dispatch(
+      addToastAction({ id: uuidv4(), content, time: option?.time ?? 3000, type: type ?? 'error' }),
+    );
   }, []);
 
   return openToast;


### PR DESCRIPTION
[CB-171]

### 🔨 Jira 태스크

- 

### 📐 구현한 내용

- ToastConfirm 컴포넌트 및 훅 추가
  - useToastConfirm 훅 사용, 인자로 confirm 시 실행 할 callback함수 전달 필요
  - redux에서는 non-serializable한 데이터 사용을 권장 하기 때문에 executeCallback 상태를 두어 true가 되면 커스텀 훅에 넘겨주었던 callback을 실행하도록 함
 
  ![image](https://user-images.githubusercontent.com/2215762/183579395-beda97c7-5706-4456-85ae-7f28eeb397df.png)


- ToastMessage 타입 추가
  - 'success' | 'error'
  - 기본은 error 타입이다.
  - openToast에 message 다음 인자로 type을 줄 수 있다.
  
  ![image](https://user-images.githubusercontent.com/2215762/183580100-7ace8f3e-5ecb-4173-947e-a1a7295561b5.png)

- z-index 수정
  - README에 반영
  - 9999 : Toast 관련 컴포넌트
  - 1000 : 레이아웃

- styled-components 타입 선언
  - 추후 theme에 추가 시 styled.d.ts에 추가 필요

### 🚧 논의 사항

-


[CB-171]: https://cocobob.atlassian.net/browse/CB-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ