### PR TITLE
[CB-318] 카카오, 구글, 애플 소셜 로그인 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25919,6 +25919,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/requireindex": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -50424,6 +50434,13 @@
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "peer": true
         },
         "requireindex": {
             "version": "1.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import PrivateRoutes from './routes/PrivateRoutes';
 import PageTransition from './components/transition/PageTransition';
 import ToastMessage from './components/Toast/ToastMessage';
 import ToastConfirm from './components/Toast/ToastConfirm';
+import GoogleRedirectHandler from './pages/Redirect/google';
+import KakaoRedirectHandler from './pages/Redirect/kakao';
 
 function App() {
   const location = useLocation();
@@ -14,6 +16,8 @@ function App() {
       <Routes key={location.pathname} location={location}>
         <Route element={<PrivateRoutes />} path="/*" />
         <Route element={<LoginPage />} path="/login" />
+        <Route element={<GoogleRedirectHandler />} path="/auth/google/callback" />
+        <Route element={<KakaoRedirectHandler />} path="/auth/kakao/callback" />
       </Routes>
     </PageTransition>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import ToastMessage from './components/Toast/ToastMessage';
 import ToastConfirm from './components/Toast/ToastConfirm';
 import GoogleRedirectHandler from './pages/Redirect/google';
 import KakaoRedirectHandler from './pages/Redirect/kakao';
+import AppleRedirectHandler from './pages/Redirect/apple';
 
 function App() {
   const location = useLocation();
@@ -18,6 +19,7 @@ function App() {
         <Route element={<LoginPage />} path="/login" />
         <Route element={<GoogleRedirectHandler />} path="/auth/google/callback" />
         <Route element={<KakaoRedirectHandler />} path="/auth/kakao/callback" />
+        <Route element={<AppleRedirectHandler />} path="/auth/apple/callback" />
       </Routes>
     </PageTransition>
   );

--- a/src/pages/Login/api.ts
+++ b/src/pages/Login/api.ts
@@ -1,3 +1,4 @@
+import { IAuthenticatedUser } from '@/@type/user';
 import axios from '@/utils/api';
 
 export async function checkEmailDuplicated(email: string) {
@@ -13,4 +14,12 @@ export async function checkEmailDuplicated(email: string) {
 
     return { isAvailable: false, message: '알 수 없는 에러가 발생하였습니다.' };
   }
+}
+export async function googleLogin(): Promise<IAuthenticatedUser> {
+  const { data } = await axios.get('/users/google', { headers: { mode: 'no-cors' } });
+  return data;
+}
+export async function kakaoLogin(): Promise<IAuthenticatedUser> {
+  const { data } = await axios.get('/users/kakao');
+  return data;
 }

--- a/src/pages/Login/api.ts
+++ b/src/pages/Login/api.ts
@@ -1,4 +1,3 @@
-import { IAuthenticatedUser } from '@/@type/user';
 import axios from '@/utils/api';
 
 export async function checkEmailDuplicated(email: string) {
@@ -14,12 +13,4 @@ export async function checkEmailDuplicated(email: string) {
 
     return { isAvailable: false, message: '알 수 없는 에러가 발생하였습니다.' };
   }
-}
-export async function googleLogin(): Promise<IAuthenticatedUser> {
-  const { data } = await axios.get('/users/google', { headers: { mode: 'no-cors' } });
-  return data;
-}
-export async function kakaoLogin(): Promise<IAuthenticatedUser> {
-  const { data } = await axios.get('/users/kakao');
-  return data;
 }

--- a/src/pages/Login/components/SocialLoginForm.tsx
+++ b/src/pages/Login/components/SocialLoginForm.tsx
@@ -3,8 +3,12 @@ import { SocialLoginButton, FormWrapper } from './SocialLoginForm.style';
 export default function SocialLoginForm() {
   return (
     <FormWrapper>
-      <SocialLoginButton>구글 계정으로 로그인</SocialLoginButton>
-      <SocialLoginButton className="kakao">카카오 계정으로 로그인</SocialLoginButton>
+      <SocialLoginButton>
+        <a href="https://api.petalog.us/v1/users/google">구글 계정으로 로그인</a>
+      </SocialLoginButton>
+      <SocialLoginButton className="kakao">
+        <a href="https://api.petalog.us/v1/users/kakao">카카오 계정으로 로그인</a>
+      </SocialLoginButton>
       <SocialLoginButton className="apple">애플 계정으로 로그인</SocialLoginButton>
     </FormWrapper>
   );

--- a/src/pages/Login/components/SocialLoginForm.tsx
+++ b/src/pages/Login/components/SocialLoginForm.tsx
@@ -4,12 +4,14 @@ export default function SocialLoginForm() {
   return (
     <FormWrapper>
       <SocialLoginButton>
-        <a href="https://api.petalog.us/v1/users/google">구글 계정으로 로그인</a>
+        <a href={`${import.meta.env.VITE_API_BASE_URL}/users/google`}>구글 계정으로 로그인</a>
       </SocialLoginButton>
       <SocialLoginButton className="kakao">
-        <a href="https://api.petalog.us/v1/users/kakao">카카오 계정으로 로그인</a>
+        <a href={`${import.meta.env.VITE_API_BASE_URL}/users/kakao`}>카카오 계정으로 로그인</a>
       </SocialLoginButton>
-      <SocialLoginButton className="apple">애플 계정으로 로그인</SocialLoginButton>
+      <SocialLoginButton className="apple">
+        <a href={`${import.meta.env.VITE_API_BASE_URL}/users/apple`}>애플 계정으로 로그인</a>
+      </SocialLoginButton>
     </FormWrapper>
   );
 }

--- a/src/pages/Redirect/apple.tsx
+++ b/src/pages/Redirect/apple.tsx
@@ -1,0 +1,5 @@
+import useRedirect from './hooks/useRedirect';
+
+export default function AppleRedirectHandler() {
+  return useRedirect(null, 'apple');
+}

--- a/src/pages/Redirect/google.tsx
+++ b/src/pages/Redirect/google.tsx
@@ -1,0 +1,5 @@
+import useRedirect from './hooks/useRedirect';
+
+export default function GoogleRedirectHandler() {
+  return useRedirect(null, 'google');
+}

--- a/src/pages/Redirect/hooks/useRedirect.tsx
+++ b/src/pages/Redirect/hooks/useRedirect.tsx
@@ -7,7 +7,10 @@ import { useAppDispatch } from '@/store/config';
 import { setCredentials } from '@/store/slices/authSlice';
 import Layout from '@/components/layout/Layout';
 
-export default function useRedirect(children: ReactNode, socialLoginType: 'kakao' | 'google') {
+export default function useRedirect(
+  children: ReactNode,
+  socialLoginType: 'kakao' | 'google' | 'apple',
+) {
   const [searchParams] = useSearchParams();
   const dispatch = useAppDispatch();
   const [isLoading, setIsLoading] = useState(true);

--- a/src/pages/Redirect/hooks/useRedirect.tsx
+++ b/src/pages/Redirect/hooks/useRedirect.tsx
@@ -1,0 +1,32 @@
+import { ReactNode, useEffect, useState } from 'react';
+import axios from '@/utils/api';
+import { IAuthenticatedUser } from '@/@type/user';
+import { IGenericResponse } from '@/store/api/types';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { useAppDispatch } from '@/store/config';
+import { setCredentials } from '@/store/slices/authSlice';
+import Layout from '@/components/layout/Layout';
+
+export default function useRedirect(children: ReactNode, socialLoginType: 'kakao' | 'google') {
+  const [searchParams] = useSearchParams();
+  const dispatch = useAppDispatch();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function redirect() {
+      const code = searchParams.get('code');
+      const {
+        data: { data },
+      } = await axios.get<IGenericResponse<IAuthenticatedUser>>(
+        `/users/login/oauth/${socialLoginType}?code=${code}`,
+      );
+      if (data.userId) {
+        dispatch(setCredentials(data));
+        setIsLoading(false);
+      }
+    }
+    redirect();
+  }, []);
+
+  return isLoading ? <Layout>{children}</Layout> : <Navigate to="/" replace />;
+}

--- a/src/pages/Redirect/kakao.tsx
+++ b/src/pages/Redirect/kakao.tsx
@@ -1,0 +1,5 @@
+import useRedirect from './hooks/useRedirect';
+
+export default function KakaoRedirectHandler() {
+  return useRedirect(null, 'kakao');
+}

--- a/src/store/api/petApi.ts
+++ b/src/store/api/petApi.ts
@@ -10,7 +10,7 @@ export const petApiSlice = apiSlice.injectEndpoints({
     }),
     getBreeds: builder.query<IBreeds[], void>({
       query: () => '/pets/breeds',
-      transformResponse: (response: IGenericResponse) => response.data as IBreeds[],
+      transformResponse: (response: IGenericResponse<IBreeds[]>) => response.data,
       providesTags: (result) =>
         result
           ? [...result.map((value) => ({ type: 'Breed' as const, id: value.id }))]
@@ -37,11 +37,11 @@ export const petApiSlice = apiSlice.injectEndpoints({
           body: formData,
         };
       },
-      transformResponse: (response: IGenericResponse) => response.data as { petId: number },
+      transformResponse: (response: IGenericResponse<{ petId: number }>) => response.data,
     }),
     getPets: builder.query<IPet[], void>({
       query: () => '/pets',
-      transformResponse: (response: IGenericResponse) => response.data as IPet[],
+      transformResponse: (response: IGenericResponse<IPet[]>) => response.data,
       providesTags: (result) =>
         result
           ? [
@@ -52,7 +52,7 @@ export const petApiSlice = apiSlice.injectEndpoints({
     }),
     getPetsDetail: builder.query<IPetInformation, number>({
       query: (id: number) => `/pets/${id}`,
-      transformResponse: (response: IGenericResponse) => response.data as IPetInformation,
+      transformResponse: (response: IGenericResponse<IPetInformation>) => response.data,
       providesTags: (result) => [{ type: 'Pet' as const, id: result?.id }],
     }),
     updatePetData: builder.mutation<

--- a/src/store/api/productApi.ts
+++ b/src/store/api/productApi.ts
@@ -6,11 +6,11 @@ export const productApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getProduct: builder.query<IProductList, void>({
       query: () => '/products/search',
-      transformResponse: (response: IGenericResponse) => response.data as IProductList,
+      transformResponse: (response: IGenericResponse<IProductList>) => response.data,
     }),
     getProductDetail: builder.query<IProductDetail, number>({
       query: (id) => `/products/${id}`,
-      transformResponse: (response: IGenericResponse) => response.data as IProductDetail,
+      transformResponse: (response: IGenericResponse<IProductDetail>) => response.data,
     }),
   }),
 });

--- a/src/store/api/types.ts
+++ b/src/store/api/types.ts
@@ -1,6 +1,6 @@
-export interface IGenericResponse {
+export interface IGenericResponse<T> {
   status: number;
   message: string;
   code: string;
-  data: unknown;
+  data: T;
 }

--- a/src/store/api/userApi.ts
+++ b/src/store/api/userApi.ts
@@ -8,7 +8,7 @@ export const userApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getUser: builder.query<IUser, void>({
       query: () => '/users',
-      transformResponse: (response: IGenericResponse) => response.data as IUser,
+      transformResponse: (response: IGenericResponse<IUser>) => response.data,
       providesTags: ['User'],
     }),
     login: builder.mutation<IAuthenticatedUser, ILoginForm>({
@@ -17,16 +17,16 @@ export const userApiSlice = apiSlice.injectEndpoints({
         method: 'POST',
         body: credentials,
       }),
-      transformResponse: (loginResult: IGenericResponse) => loginResult.data as IAuthenticatedUser,
+      transformResponse: (loginResult: IGenericResponse<IAuthenticatedUser>) => loginResult.data,
     }),
-    logout: builder.mutation<IGenericResponse, void>({
+    logout: builder.mutation<IGenericResponse<void>, void>({
       query: () => ({
         url: '/users',
         method: 'DELETE',
       }),
       invalidatesTags: ['User'],
     }),
-    signUp: builder.mutation<IGenericResponse, ISignUpForm>({
+    signUp: builder.mutation<IGenericResponse<{ userId: number }>, ISignUpForm>({
       query: (data) => ({
         url: '/users/new',
         method: 'POST',


### PR DESCRIPTION
[CB-317]

### 🔨 Jira 태스크

- CB-319 애플 로그인
- CB-320 카카오 로그인
- CB-321 구글 로그인
- CB-322 IGenericResponse 타입 수정

### 📐 구현한 내용

- 카카오 로그인 및 구글, 애플 로그인 연동하였습니다!
  - OAuth 플로우에 따라 링크를 이용하여 요청을 보내어 각 소셜 서비스 인증 성공 후 전달받은 code를 펫탈로그 서비스 서버로 보내어 로그인 처리를 진행합니다.
  - 공통된 로직을 수행하여 useRedirect라는 커스텀 훅으로 분리하여 관리하도록 하였습니다
- API 응답 공통 타입인 IGenericResponse타입의 data가 unknown이던 것을 제네릭으로 바꾸어 활용할 수 있도록 하였습니다.

### 🚧 논의 사항

- 애플로그인은 배포환경에서 테스트가 필요합니다


[CB-317]: https://cocobob.atlassian.net/browse/CB-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ