### PR TITLE
Cb 238 refactor/products

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="text/javascript"

--- a/src/pages/Products/components/Filter/FilterModal.tsx
+++ b/src/pages/Products/components/Filter/FilterModal.tsx
@@ -59,26 +59,29 @@ export default function FilterModal({ setPage, close }: FilterModalProps) {
   };
 
   return (
-    <div className="fixed bottom-0 z-[9000] w-full max-w-[425px] h-4/5 rounded-t-[10px] bg-white shadow-sm">
-      <div className="flex flex-col w-full h-full p-2">
-        {filterType === 'all' && (
-          <FilterAllContent
-            close={close}
-            selectedFilters={selectedFilters}
-            setFilter={setFilter}
-            onClickSave={onClickSave}
-            onClickShowMore={showMoreFilters}
-          />
-        )}
-        {filterType !== 'all' && (
-          <FilterDetailContent
-            filterType={filterType}
-            currentSelectedFilters={selectedFilters}
-            showAllFilters={showAllFilters}
-            saveDetailFilter={setFilters}
-          />
-        )}
+    <>
+      <div className="fixed bottom-0 z-[9000] w-full max-w-[425px] h-4/5 rounded-t-[10px] bg-white shadow-sm">
+        <div className="flex flex-col w-full h-full p-2">
+          {filterType === 'all' && (
+            <FilterAllContent
+              close={close}
+              selectedFilters={selectedFilters}
+              setFilter={setFilter}
+              onClickSave={onClickSave}
+              onClickShowMore={showMoreFilters}
+            />
+          )}
+          {filterType !== 'all' && (
+            <FilterDetailContent
+              filterType={filterType}
+              currentSelectedFilters={selectedFilters}
+              showAllFilters={showAllFilters}
+              saveDetailFilter={setFilters}
+            />
+          )}
+        </div>
       </div>
-    </div>
+      <div className="z-[8000] bg-[#00000029] fixed top-0 w-full h-full" />
+    </>
   );
 }

--- a/src/pages/Products/components/Search/header.tsx
+++ b/src/pages/Products/components/Search/header.tsx
@@ -6,13 +6,12 @@ import { useSearchParams } from 'react-router-dom';
 interface ISearch {
   searchInputValue: string;
   setSearchInputValue: Dispatch<SetStateAction<string>>;
-  setMainContent: any;
   goBack: () => void;
   onClickSearch: any;
 }
 
 export default function SearchHeader(props: ISearch) {
-  const { searchInputValue, setSearchInputValue, goBack, onClickSearch, setMainContent } = props;
+  const { searchInputValue, setSearchInputValue, goBack, onClickSearch } = props;
   const [searchParams] = useSearchParams();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -39,7 +38,6 @@ export default function SearchHeader(props: ISearch) {
         <input
           className="w-full bg-slate-200 p-1 px-3 rounded-[10px]"
           onChange={(e) => {
-            setMainContent('Search');
             setSearchInputValue(e.target.value);
           }}
           value={searchInputValue}

--- a/src/pages/Products/components/Search/index.tsx
+++ b/src/pages/Products/components/Search/index.tsx
@@ -20,7 +20,7 @@ export default function Search(props: ISearch) {
   //   return '';
   // };
   return (
-    <div className="w-full h-full pt-[50px]">
+    <div className="w-full h-full">
       {searchInputValue !== '' && (
         <RelatedSearchKeywordContainer>
           {relatedWords.map((word, idx) => (
@@ -34,7 +34,7 @@ export default function Search(props: ISearch) {
           ))}
         </RelatedSearchKeywordContainer>
       )}
-      {searchInputValue === '' && <div>추천검색어</div>}
+      <div>추천검색어</div>
     </div>
   );
 }

--- a/src/pages/Products/components/Search/modal.tsx
+++ b/src/pages/Products/components/Search/modal.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Portal from '@/portal';
+import SearchHeader from '@/pages/Products/components/Search/header';
+import RecommandContent from '@/pages/Products/components/Search';
+
+export default function SearchModal({
+  onClose,
+  searchInputValue,
+  setSearchInputValue,
+  onClickSearch,
+}: any) {
+  return (
+    <Portal>
+      <div className="fixed top-0 left-0 right-0 mx-auto flex flex-col w-full max-w-[425px] bg-white">
+        <SearchHeader
+          searchInputValue={searchInputValue}
+          setSearchInputValue={setSearchInputValue}
+          onClickSearch={onClickSearch}
+          goBack={onClose}
+        />
+        {searchInputValue === '' && (
+          <div className="w-full h-screen">
+            <RecommandContent searchInputValue={searchInputValue} onClickSearch={onClickSearch} />
+          </div>
+        )}
+      </div>
+    </Portal>
+  );
+}

--- a/src/pages/Products/index.tsx
+++ b/src/pages/Products/index.tsx
@@ -66,6 +66,7 @@ export default function ProductsPage() {
     [inViewRef],
   );
 
+  const isAafco = (key) => key === 'aafco';
   const combineList = (nextList: ProductPreviewType[]) => (prevList: ProductPreviewType[]) =>
     prevList.concat(nextList);
 
@@ -90,7 +91,8 @@ export default function ProductsPage() {
     const entries = searchParams.entries();
     const newFilters = Array.from(entries).reduce((filterObject, [key, value]) => {
       if (key === 'name') setSearchKeyword(value);
-      return { ...filterObject, [key]: key === 'aafco' ? value === 'true' : value };
+      const entryValue = isAafco(key) ? value === 'true' : value;
+      return { ...filterObject, [key]: entryValue };
     }, {});
 
     setFilters(newFilters);

--- a/src/pages/Products/index.tsx
+++ b/src/pages/Products/index.tsx
@@ -4,27 +4,13 @@ import { useInView } from 'react-intersection-observer';
 
 import Layout from '@/components/layout/Layout';
 import ProductItem from '@/components/Product';
+import ProductSearchModal from '@/pages/Products/components/Search/modal';
 import { useLazyGetProductQuery } from '@/store/api/productApi';
-import { concatClasses } from '@/utils/libs/concatClasses';
 import { ProductPreviewType } from '@/@type/product';
 import Header from './components/Header';
-import SearchPage from './components/Search';
-import SearchHeader from './components/Search/header';
 
 import CategoryTabButton from './components/CategoryTabButton';
 import FilterModal from './components/Filter/FilterModal';
-
-const MainContent = {
-  AllProducts: 'AllProducts',
-  Search: 'Search',
-  SearchResults: 'SearchResults',
-  OnlySearch: 'OnlySearch', // todo: 네이밍 좀 더 명확하게
-} as const;
-
-type MainContentType = typeof MainContent[keyof typeof MainContent]; // 'AllProducts' | 'Search' | 'SearchResults' | 'OnlySearch'
-// interface LocationState {
-//   MainContent: MainContentType;
-// }
 
 type CategoryType = '사료' | '간식' | '영양제';
 const categoryList: CategoryType[] = ['사료', '간식', '영양제'];
@@ -58,26 +44,18 @@ MemoizedProductItem.displayName = 'ProductItem';
 
 export default function ProductsPage() {
   const firstTrigger = useRef(false);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
-  const [category, setCategory] = useState<CategoryType>('사료');
-  const [mainContent, setMainContent] = useState<MainContentType>('AllProducts');
-
   const ref = useRef<HTMLDivElement>();
-  const { ref: inViewRef, inView } = useInView({ threshold: 0, rootMargin: '150px 0px 0px 0px' });
-  const [searchInputValue, setSearchInputValue] = useState('');
 
+  const [category, setCategory] = useState<CategoryType>('사료');
+  const [onSearch, setOnSearch] = useState<boolean>(false);
+  const [searchKeyword, setSearchKeyword] = useState('');
   const [page, setPage] = useState<number>(0);
-  // eslint-disable-next-line no-unused-vars
-  const [name, setName] = useState('');
-  // eslint-disable-next-line no-unused-vars
-  const [sort, setSort] = useState();
-  const [aafco, setAafco] = useState(false);
-  const [filters, setFilters] = useState<any>([]);
-  const [trigger, { isFetching, data, isSuccess }] = useLazyGetProductQuery();
-  const [productList, setProductList] = useState<ProductPreviewType[]>([]);
+  const [filters, setFilters] = useState<any>({ aafco: false });
   const [searchResults, setSearchResults] = useState<ProductPreviewType[]>([]);
 
+  const { ref: inViewRef, inView } = useInView({ threshold: 0, rootMargin: '150px 0px 0px 0px' });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [trigger, { isFetching, data, isSuccess }] = useLazyGetProductQuery();
   const { filterModal, openFilterModal, closeFilterModal } = useFilterModal();
 
   const setInViewRef = useCallback(
@@ -88,48 +66,32 @@ export default function ProductsPage() {
     [inViewRef],
   );
 
+  const combineList = (nextList: ProductPreviewType[]) => (prevList: ProductPreviewType[]) =>
+    prevList.concat(nextList);
+
   const showAllProducts = () => {
-    if (mainContent === 'OnlySearch') navigate(-1);
-    else {
-      setPage(0);
-      setMainContent('AllProducts');
-      setSearchParams({});
-    }
+    setOnSearch(false);
+    setSearchParams({ aafco: false });
   };
 
-  const onClickSearch = () => {
-    setSearchParams({ ...searchParams, name: searchInputValue });
-  };
-
-  // const onSaveFilter = (aafco?:boolean, )=>{
-
-  // }
+  const onClickSearch = () => setSearchParams({ ...searchParams, name: searchKeyword });
 
   useEffect(() => {
+    setPage(0);
     firstTrigger.current = true;
     setSearchResults([]);
-    setProductList([]);
-    setAafco(false);
+    setSearchKeyword('');
     if (searchParams.toString().length === 0) {
-      setMainContent('AllProducts');
+      setFilters({ aafco: false });
+      trigger({ page: 0 });
       return;
     }
 
-    const newFilters: { [key: string]: string | boolean } = {};
     const entries = searchParams.entries();
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const entry of entries) {
-      const [key, value] = entry;
-      if (key === 'aafco') setAafco(value === 'true');
-      if (key === 'name') {
-        if (!value) setMainContent('AllProducts');
-        else setMainContent('SearchResults');
-        setName(value);
-      }
-      console.log(key, value);
-      newFilters[key] = value;
-    }
+    const newFilters = Array.from(entries).reduce((filterObject, [key, value]) => {
+      if (key === 'name') setSearchKeyword(value);
+      return { ...filterObject, [key]: key === 'aafco' ? value === 'true' : value };
+    }, {});
 
     setFilters(newFilters);
   }, [searchParams]);
@@ -143,125 +105,89 @@ export default function ProductsPage() {
 
   useEffect(() => {
     if (!firstTrigger.current) return;
-    if (!isFetching && !data?.last && inView) {
-      trigger({ ...filters, page: page + 1 });
-      setPage((prevState) => prevState + 1);
-    }
+    if (isFetching || data?.last || !inView) return;
+    trigger({ ...filters, page: page + 1 });
+    setPage((prevState) => prevState + 1);
   }, [inView, isFetching, data]);
-
-  const setter = (prevList: ProductPreviewType[]) => {
-    const newList = prevList.concat(data?.productList ?? []);
-    return newList;
-  };
 
   useEffect(() => {
     if (!isSuccess) return;
-
-    if (mainContent === 'AllProducts') setProductList(setter);
-    else {
-      setSearchResults(setter);
-    }
+    const productList = data?.productList ?? [];
+    setSearchResults(combineList(productList));
   }, [data]);
 
   return (
     <Layout footer>
+      {onSearch && (
+        <ProductSearchModal
+          onClose={() => showAllProducts()}
+          onClickSearch={onClickSearch}
+          searchInputValue={searchKeyword}
+          setSearchInputValue={setSearchKeyword}
+        />
+      )}
       <div className="fixed top-0 left-0 right-0 mx-auto flex flex-col w-full max-w-[425px]">
-        {mainContent === 'AllProducts' ? (
-          <Header title={'제품목록'} goSearchPage={() => setMainContent('Search')} />
-        ) : (
-          <SearchHeader
-            searchInputValue={searchInputValue}
-            setSearchInputValue={setSearchInputValue}
-            onClickSearch={onClickSearch}
-            setMainContent={setMainContent}
-            goBack={showAllProducts}
-          />
-        )}
-        {mainContent !== 'Search' && mainContent !== 'OnlySearch' && (
-          <div
-            className={concatClasses(
-              'flex flex-col w-full max-w-[425px] bg-white',
-              mainContent !== 'SearchResults' ? 'pt-[50px]' : '',
-            )}
-          >
-            <div className="h-12 w-full flex justify-between items-center">
-              {categoryList.map((categoryName) => (
-                <CategoryTabButton
-                  key={categoryName}
-                  name={categoryName}
-                  onClick={() => setCategory(categoryName)}
-                  isOn={category === categoryName}
-                />
-              ))}
-            </div>
-            <div className="w-full px-3 py-1 border-t border-b border-gray-200 flex items-center justify-between">
-              <div className="flex gap-3">
+        <Header title={'제품목록'} goSearchPage={() => setOnSearch(true)} />
+        <div className={'flex flex-col w-full max-w-[425px] bg-white pt-[50px]'}>
+          <div className="h-12 w-full flex justify-between items-center">
+            {categoryList.map((categoryName) => (
+              <CategoryTabButton
+                key={categoryName}
+                name={categoryName}
+                onClick={() => setCategory(categoryName)}
+                isOn={category === categoryName}
+              />
+            ))}
+          </div>
+          <div className="w-full px-3 py-1 border-t border-b border-gray-200 flex items-center justify-between">
+            <div className="flex gap-3">
+              <button className="rounded-lg border border-gray-700 px-4" onClick={openFilterModal}>
+                필터
+              </button>
+              {(filters?.aafco || searchKeyword) && (
                 <button
-                  className="rounded-lg border border-gray-700 px-4"
-                  onClick={openFilterModal}
+                  className="px-2 rounded-[10px] border border-gray-700"
+                  onClick={() => setSearchParams({ aafco: false })}
                 >
-                  필터
+                  reset
                 </button>
-                {(filters.length > 0 || aafco || name) && (
-                  <button
-                    className="px-2 rounded-[10px] border border-gray-700"
-                    onClick={() => {
-                      setName('');
-                      setFilters([]);
-                      setSearchParams({});
-                    }}
-                  >
-                    reset
-                  </button>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                <label htmlFor="aafco-filter" className="text-gray-700 text-[0.8rem]">
-                  AAFCO 만족 상품
-                </label>
-                <input
-                  type="checkbox"
-                  name=""
-                  id="aafco-filter"
-                  checked={aafco}
-                  onChange={(e) => {
-                    const {
-                      target: { checked },
-                    } = e;
-                    setAafco(checked);
-                    console.log(name);
-                    setSearchParams({ ...searchParams, name, aafco: String(checked) });
-                  }}
-                />
-              </div>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <label htmlFor="aafco-filter" className="text-gray-700 text-[0.8rem]">
+                AAFCO 만족 상품
+              </label>
+              <input
+                type="checkbox"
+                name=""
+                id="aafco-filter"
+                checked={filters?.aafco}
+                onChange={({ target: { checked } }) =>
+                  setSearchParams({
+                    ...searchParams,
+                    name: searchKeyword,
+                    aafco: checked,
+                  })
+                }
+              />
             </div>
           </div>
-        )}
+        </div>
       </div>
       <div className="w-full h-full">
-        {mainContent !== 'Search' && mainContent !== 'OnlySearch' && (
-          <div className="pt-[150px] pb-[60px]">
-            {(mainContent === 'AllProducts' ? productList : searchResults)?.map((product) => (
-              <MemoizedProductItem key={product.productId} product={product} />
-            ))}
-            {!isFetching && !data?.last && (
-              <div ref={setInViewRef} className="w-full h-20 flex items-center justify-center">
-                LoadMore
-              </div>
-            )}
-          </div>
-        )}
-        {(mainContent === 'Search' || mainContent === 'OnlySearch') && (
-          <SearchPage searchInputValue={searchInputValue} onClickSearch={onClickSearch} />
-        )}
+        <div className="pt-[150px] pb-[60px]">
+          {searchResults?.map((product) => (
+            <MemoizedProductItem key={product.productId} product={product} />
+          ))}
+          {!isFetching && !data?.last && (
+            <div ref={setInViewRef} className="w-full h-20 flex items-center justify-center">
+              LoadMore
+            </div>
+          )}
+        </div>
         {isFetching && <p>로딩중</p>}
       </div>
-      {filterModal && (
-        <>
-          <FilterModal setPage={setPage} close={closeFilterModal} />
-          <div className="z-[8000] bg-[#00000029] fixed top-0 w-full h-full"></div>
-        </>
-      )}
+      {filterModal && <FilterModal setPage={setPage} close={closeFilterModal} />}
     </Layout>
   );
 }

--- a/src/portal.tsx
+++ b/src/portal.tsx
@@ -1,0 +1,8 @@
+import reactDom from 'react-dom';
+
+const Portal = ({ children }) => {
+  const el = document.getElementById('modal');
+  return reactDom.createPortal(children, el);
+};
+
+export default Portal;


### PR DESCRIPTION
[CB-<스토리#>]

### 🔨 Jira 태스크

-

### 📐 구현한 내용

- 검색 로직을 모달로 분리하였습니다. 기존에 사용되던 mainContent 로직를 제거하였습니다.
- 검색 로직을 분리하면서, productResult와 searchResult를 분리할 필요가  없어져, 한개로 관리하도록 수정하였습니다.
- 필터링은 추후 타입이 추가될 것을 고려하여, 현재는 aafco 조건만 초기화 하였습니다. 추후 논의가 필요합니다.
- 검색을 분리하면서, name 상태를 별도로 관리할 필요가 없어져서 제거하였습니다.
- 추후 데이터 로드 관련 초기화 로직을 커스텀 훅으로 분리하며 코드가 더욱 간결해질거 같습니다.

### 🚧 논의 사항

-
