### PR TITLE
[CB-375] 모듈 관리 변경

### DIFF
--- a/src/components/BottomSheet/BirthdayBottomSheet.tsx
+++ b/src/components/BottomSheet/BirthdayBottomSheet.tsx
@@ -1,6 +1,6 @@
 import { getDateDiff } from '@/utils/libs/date';
 import { ChangeEvent, useEffect, useMemo, useState } from 'react';
-import BottomSheet from '.';
+import BottomSheet from './BottomSheet';
 import Button from '../Button';
 import {
   BottomSheetContentWrapper,

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,59 @@
+import { closeBottomSheetAction } from '@/store/slices/bottomSheetSlice';
+import { ReactNode } from 'react';
+import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
+import { createTheme, ThemeProvider } from '@mui/material';
+
+const theme = createTheme({
+  components: {
+    MuiDrawer: {
+      styleOverrides: {
+        paperAnchorBottom: {
+          borderTopRightRadius: 10,
+          borderTopLeftRadius: 10,
+          paddingTop: 10,
+        },
+        paper: {
+          margin: '0 auto',
+          maxWidth: 425,
+        },
+      },
+    },
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: 'rgba(51, 51, 51, 0.85);',
+          margin: '0 auto',
+          maxWidth: 425,
+        },
+      },
+    },
+  },
+});
+
+const BottomSheetWrapper = styled(SwipeableDrawer)``;
+
+export default function BottomSheet({
+  isOpen,
+  children,
+}: {
+  isOpen: boolean;
+  children: ReactNode;
+}) {
+  const dispatch = useDispatch();
+  const closeBottomSheet = () => dispatch(closeBottomSheetAction());
+
+  return (
+    <ThemeProvider theme={theme}>
+      <BottomSheetWrapper
+        anchor={'bottom'}
+        open={isOpen}
+        onClose={closeBottomSheet}
+        onOpen={() => {}}
+      >
+        {children}
+      </BottomSheetWrapper>
+    </ThemeProvider>
+  );
+}

--- a/src/components/BottomSheet/BreedBottomSheet.tsx
+++ b/src/components/BottomSheet/BreedBottomSheet.tsx
@@ -4,7 +4,7 @@ import { useGetBreedsQuery } from '@/store/api/petApi';
 import { Dispatch, SetStateAction } from 'react';
 import { concatClasses } from '@/utils/libs/concatClasses';
 import { InputStyle } from '../Form/FormInput';
-import BottomSheet from '.';
+import BottomSheet from './BottomSheet';
 import Button from '../Button';
 import { BottomSheetContentWrapper, BreedListContainer } from './BottomSheet.style';
 

--- a/src/components/BottomSheet/MonthsAgeBottomSheet.tsx
+++ b/src/components/BottomSheet/MonthsAgeBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import BottomSheet from '.';
+import BottomSheet from './BottomSheet';
 import Button from '../Button';
 import {
   BottomSheetContentWrapper,

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -1,59 +1,13 @@
-import { closeBottomSheetAction } from '@/store/slices/bottomSheetSlice';
-import { ReactNode } from 'react';
-import { useDispatch } from 'react-redux';
-import styled from 'styled-components';
-import SwipeableDrawer from '@mui/material/SwipeableDrawer';
-import { createTheme, ThemeProvider } from '@mui/material';
+import BottomSheet from './BottomSheet';
+import BottomSheetHeader from './BottomSheetHeader';
+import BreedBottomSheet from './BreedBottomSheet';
+import BirthdayBottomSheet from './BirthdayBottomSheet';
+import MonthsAgeBottomSheet from './MonthsAgeBottomSheet';
 
-const theme = createTheme({
-  components: {
-    MuiDrawer: {
-      styleOverrides: {
-        paperAnchorBottom: {
-          borderTopRightRadius: 10,
-          borderTopLeftRadius: 10,
-          paddingTop: 10,
-        },
-        paper: {
-          margin: '0 auto',
-          maxWidth: 425,
-        },
-      },
-    },
-    MuiBackdrop: {
-      styleOverrides: {
-        root: {
-          backgroundColor: 'rgba(51, 51, 51, 0.85);',
-          margin: '0 auto',
-          maxWidth: 425,
-        },
-      },
-    },
-  },
-});
-
-const BottomSheetWrapper = styled(SwipeableDrawer)``;
-
-export default function BottomSheet({
-  isOpen,
-  children,
-}: {
-  isOpen: boolean;
-  children: ReactNode;
-}) {
-  const dispatch = useDispatch();
-  const closeBottomSheet = () => dispatch(closeBottomSheetAction());
-
-  return (
-    <ThemeProvider theme={theme}>
-      <BottomSheetWrapper
-        anchor={'bottom'}
-        open={isOpen}
-        onClose={closeBottomSheet}
-        onOpen={() => {}}
-      >
-        {children}
-      </BottomSheetWrapper>
-    </ThemeProvider>
-  );
-}
+export {
+  BottomSheet,
+  BottomSheetHeader,
+  BreedBottomSheet,
+  BirthdayBottomSheet,
+  MonthsAgeBottomSheet,
+};

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -1,0 +1,4 @@
+import FormInput from './FormInput';
+import FormButton from './FormButton';
+
+export { FormButton, FormInput };

--- a/src/pages/Daily/BodyWeight/index.tsx
+++ b/src/pages/Daily/BodyWeight/index.tsx
@@ -1,6 +1,5 @@
 import Layout from '@/components/layout/Layout';
-import FormInput from '@/components/Form/FormInput';
-import FormButton from '@/components/Form/FormButton';
+import { FormInput, FormButton } from '@/components/Form';
 
 export default function DailyBodyWeight() {
   return (

--- a/src/pages/Login/EmailLoginSheet.tsx
+++ b/src/pages/Login/EmailLoginSheet.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector } from '@/store/config';
 import { selectIsLoggedIn } from '@/store/slices/authSlice';
 import { useLoginMutation } from '@/store/api/userApi';
 import { closeBottomSheetAction } from '@/store/slices/bottomSheetSlice';
-import BottomSheet from '@/components/BottomSheet';
+import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import useToastMessage from '@/utils/hooks/useToastMessage';
 import EmailLoginForm from './components/EmailLoginForm';
 import JoinLink from './components/JoinLink';

--- a/src/pages/Login/SignUpSheet.tsx
+++ b/src/pages/Login/SignUpSheet.tsx
@@ -1,4 +1,4 @@
-import BottomSheet from '@/components/BottomSheet';
+import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import { useSignUpMutation } from '@/store/api/userApi';
 import useBottomSheet from '@/utils/hooks/useBottomSheet';
 import SignUpForm from './components/SignUpForm';

--- a/src/pages/Login/components/EmailLoginForm.tsx
+++ b/src/pages/Login/components/EmailLoginForm.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import FormInput from '@/components/Form/FormInput';
-import FormButton from '@/components/Form/FormButton';
+import { FormInput, FormButton } from '@/components/Form';
 import { ILoginForm } from '../types';
 import { LoginForm } from './EmailLoginForm.style';
 

--- a/src/pages/Login/components/SignUpForm.tsx
+++ b/src/pages/Login/components/SignUpForm.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-unused-vars */
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import FormButton from '@/components/Form/FormButton';
-import FormInput from '@/components/Form/FormInput';
+import { FormInput, FormButton } from '@/components/Form';
 
 import useToastMessage from '@/utils/hooks/useToastMessage';
 import { checkEmailDuplicated } from '../api';

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -3,13 +3,16 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { EffectCoverflow, Pagination } from 'swiper';
 import { Swiper, SwiperProps, SwiperSlide } from 'swiper/react';
+
 import { useGetUserQuery } from '@/store/api/userApi';
-import useLogout from '@/utils/hooks/useLogout';
-import useCurrentPet from '@/utils/hooks/useCurrentPet';
+import { useLazyGetRecommendProductQuery } from '@/store/api/productApi';
+
 import Layout from '@/components/layout/Layout';
 import ContentsContainer from '@/components/ContentsContainer';
+
+import { useLogout, useCurrentPet } from '@/utils/hooks';
+
 import doctor from '@/assets/image/main_doctor.png';
-import { useLazyGetRecommendProductQuery } from '@/store/api/productApi';
 import { ReactComponent as RecommendIcon } from '@/assets/icon/navbar_food.svg';
 import { ReactComponent as TrashIcon } from '@/assets/icon/trash_icon.svg';
 import { ReactComponent as DogFoodIcon } from '@/assets/icon/dog_food.svg';

--- a/src/pages/Mypage/Main.tsx
+++ b/src/pages/Mypage/Main.tsx
@@ -3,9 +3,7 @@ import { IPet } from '@/@type/pet';
 import Layout from '@/components/layout/Layout';
 import { useGetPetsQuery } from '@/store/api/petApi';
 import { useGetUserQuery } from '@/store/api/userApi';
-import useConfirm from '@/utils/hooks/useConfirm';
-import useLogout from '@/utils/hooks/useLogout';
-import useWithdrawal from '@/utils/hooks/useWithdrawal';
+import { useConfirm, useLogout, useWithdrawal } from '@/utils/hooks';
 import AddPetBUtton from './components/AddPetButton';
 import PetSimpleInfo from './components/PetSimpleInfo';
 import {

--- a/src/pages/Mypage/Profile.tsx
+++ b/src/pages/Mypage/Profile.tsx
@@ -1,6 +1,5 @@
 import Layout from '@/components/layout/Layout';
-import FormInput from '@/components/Form/FormInput';
-import FormButton from '@/components/Form/FormButton';
+import { FormInput, FormButton } from '@/components/Form';
 
 export default function ProfilePage() {
   return (

--- a/src/pages/Mypage/pets/[id].tsx
+++ b/src/pages/Mypage/pets/[id].tsx
@@ -5,32 +5,31 @@ import { useForm } from 'react-hook-form';
 import { QuestionWrapper } from '@/pages/RegisterPet/index.style';
 import ContentsContainer from '@/components/ContentsContainer';
 import Layout from '@/components/layout/Layout';
-import FormInput, { InputStyle, Label } from '@/components/Form/FormInput';
-import FormButton from '@/components/Form/FormButton';
+import { FormInput, FormButton } from '@/components/Form';
+import { InputStyle, Label } from '@/components/Form/FormInput';
 
 import { ActivityLevelType, IBreeds, IPetInformation, PetSexType, PetInfoForm } from '@/@type/pet';
+import { useAppSelector } from '@/store/config';
 import {
   useDeletePetMutation,
   useGetPetsDetailQuery,
   useUpdatePetDataMutation,
 } from '@/store/api/petApi';
-import useSelectImage from '@/utils/hooks/useSelectImage';
-import useBottomSheet from '@/utils/hooks/useBottomSheet';
-import useConfirm from '@/utils/hooks/useConfirm';
-import useToastMessage from '@/utils/hooks/useToastMessage';
+
+import { useSelectImage, useBottomSheet, useConfirm, useToastMessage } from '@/utils/hooks';
 import { getFileFromObjectURL } from '@/utils/libs/getFileFromObjectURL';
-import BreedBottomSheet from '@/components/BottomSheet/BreedBottomSheet';
-import BirthdayBottomSheet from '@/components/BottomSheet/BirthdayBottomSheet';
-import MonthsAgeBottomSheet from '@/components/BottomSheet/MonthsAgeBottomSheet';
+import {
+  BreedBottomSheet,
+  BirthdayBottomSheet,
+  MonthsAgeBottomSheet,
+} from '@/components/BottomSheet';
 import useAgeBottomSheet from '@/components/BottomSheet/hooks/useAgeBottomSheet';
 
 import { ReactComponent as TrashIcon } from '@/assets/icon/trash_icon.svg';
 import { ReactComponent as EditIcon } from '@/assets/icon/edit_icon.svg';
 import { ReactComponent as CalendarIcon } from '@/assets/icon/calendar_icon.svg';
-
 import PetDefault from '@/assets/image/pet_default.png';
 
-import { useAppSelector } from '@/store/config';
 import {
   AgeDescription,
   AgeSelectButton,

--- a/src/pages/RegisterPet/Step1.tsx
+++ b/src/pages/RegisterPet/Step1.tsx
@@ -1,7 +1,6 @@
-import { useForm } from 'react-hook-form';
-import FormInput from '@/components/Form/FormInput';
-import FormButton from '@/components/Form/FormButton';
 import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { FormInput, FormButton } from '@/components/Form';
 import { ButtonWrapper, Form, PageContainer, QuestionText, SubQuestionText } from './index.style';
 import { StepPageProps } from './type';
 

--- a/src/pages/RegisterPet/Step3.tsx
+++ b/src/pages/RegisterPet/Step3.tsx
@@ -1,15 +1,16 @@
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+
 import { IBreeds } from '@/@type/pet';
 import FormButton from '@/components/Form/FormButton';
 import { InputStyle } from '@/components/Form/FormInput';
+import BreedBottomSheet from '@/components/BottomSheet/BreedBottomSheet';
+
 import { useGetBreedsQuery } from '@/store/api/petApi';
 import { favBreeds } from '@/utils/constants/enrollment';
-import useBottomSheet from '@/utils/hooks/useBottomSheet';
 import { concatClasses } from '@/utils/libs/concatClasses';
-import { useState, useEffect } from 'react';
+import { useToastMessage, useBottomSheet } from '@/utils/hooks';
 
-import { useForm } from 'react-hook-form';
-import useToastMessage from '@/utils/hooks/useToastMessage';
-import BreedBottomSheet from '@/components/BottomSheet/BreedBottomSheet';
 import { ButtonWrapper, Form, PageContainer, PetNameHighlight, QuestionText } from './index.style';
 import { StepPageProps } from './type';
 

--- a/src/pages/RegisterPet/Step4.tsx
+++ b/src/pages/RegisterPet/Step4.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import BottomSheet from '@/components/BottomSheet';
+import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import Button from '@/components/Button';
 import FormButton from '@/components/Form/FormButton';
 import {
@@ -8,8 +8,7 @@ import {
   getDateDiff,
   getTotalMonthWithYearAndMonth,
 } from '@/utils/libs/date';
-import useBottomSheet from '@/utils/hooks/useBottomSheet';
-import useToastMessage from '@/utils/hooks/useToastMessage';
+import { useBottomSheet, useToastMessage } from '@/utils/hooks';
 import { ButtonWrapper, PageContainer, QuestionText, Form, PetNameHighlight } from './index.style';
 import { StepPageProps } from './type';
 

--- a/src/pages/RegisterPet/Step5.tsx
+++ b/src/pages/RegisterPet/Step5.tsx
@@ -1,9 +1,8 @@
-import { ActivityLevelType, PetSexType } from '@/@type/pet';
-import FormButton from '@/components/Form/FormButton';
-import FormInput from '@/components/Form/FormInput';
-import { concatClasses } from '@/utils/libs/concatClasses';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { ActivityLevelType, PetSexType } from '@/@type/pet';
+import { FormInput, FormButton } from '@/components/Form';
+import { concatClasses } from '@/utils/libs/concatClasses';
 import {
   PageContainer,
   QuestionText,

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -1,0 +1,27 @@
+import useBottomSheet from './useBottomSheet';
+import useConfirm from './useConfirm';
+import useCurrentPet from './useCurrentPet';
+import useCurrentPosition from './useCurrentPosition';
+import useLogout from './useLogout';
+import usePlatform from './usePlatform';
+import useSearchBreed from './useSearchBreed';
+import useSelectImage from './useSelectImage';
+import useToastMessage from './useToastMessage';
+import useUser from './useUser';
+import useWatchPosition from './useWatchPosition';
+import useWithdrawal from './useWithdrawal';
+
+export {
+  useBottomSheet,
+  useConfirm,
+  useCurrentPet,
+  useCurrentPosition,
+  useLogout,
+  usePlatform,
+  useSearchBreed,
+  useSelectImage,
+  useToastMessage,
+  useUser,
+  useWatchPosition,
+  useWithdrawal,
+};

--- a/src/utils/hooks/useCurrentPosition.tsx
+++ b/src/utils/hooks/useCurrentPosition.tsx
@@ -6,7 +6,7 @@ const defaultPosition: ILocation = {
   longitude: 127.0448556,
 };
 
-const useCurrentLocation = (options: IGeolocationOptions = {}) => {
+const useCurrentPosition = (options: IGeolocationOptions = {}) => {
   const [location, setLocation] = useState<ILocation>(defaultPosition);
   const [error, setError] = useState<string>();
 
@@ -37,4 +37,4 @@ const useCurrentLocation = (options: IGeolocationOptions = {}) => {
   return { location, error };
 };
 
-export default useCurrentLocation;
+export default useCurrentPosition;


### PR DESCRIPTION
[CB-375]

### 🔨 Jira 태스크

- [CB-375] 모듈 관리 변경

### 📐 구현한 내용

- 모듈 import/export 관리 방식 변경
  -  한 폴더 내에서 각각 파일에서 모듈 import를 하고있어 import 구문이 매우 길어지게 되었습니다. hooks나 각 컴포넌트 폴더에서는 index.tsx 내에서 하위 경로의 컴포넌트를 import 및 export하여 외부에서는 상위 폴더에서 모두 import할 수 있도록 변경하였습니다. 
  - 공통 상위 폴더를 가진 컴포넌트를 import할 때 용이합니다.

### 🚧 논의 사항

- 


[CB-375]: https://cocobob.atlassian.net/browse/CB-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-375]: https://cocobob.atlassian.net/browse/CB-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ