### PR TITLE
[CB-367] 토큰 갱신 API 뮤텍스 락 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/material": "^5.9.1",
         "@mui/styled-engine-sc": "^5.8.0",
         "@reduxjs/toolkit": "^1.8.3",
+        "async-mutex": "^0.3.2",
         "autoprefixer": "^10.4.7",
         "axios": "^0.27.2",
         "dayjs": "^1.11.4",
@@ -9431,6 +9432,14 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -29211,8 +29220,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -38273,6 +38281,14 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true,
       "optional": true
+    },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -53380,8 +53396,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@mui/material": "^5.9.1",
     "@mui/styled-engine-sc": "^5.8.0",
     "@reduxjs/toolkit": "^1.8.3",
+    "async-mutex": "^0.3.2",
     "autoprefixer": "^10.4.7",
     "axios": "^0.27.2",
     "dayjs": "^1.11.4",


### PR DESCRIPTION
[CB-367]

### 🔨 Jira 태스크


### 📐 구현한 내용

- 토큰 갱신 API 요청시 뮤텍스 락 추가
  - 토큰 갱신 시에는 다른 요청을 보내면 안됨.
  - 토큰 갱신 요청 전에 lock을 걸어 다른 요청이 가지 못하도록 막음.
  - 토큰 갱신이 된 이후에는 lock을 해제하며, 재발급 된 토큰이 헤더에 실리게 됨.

### 🚧 논의 사항

-


[CB-367]: https://cocobob.atlassian.net/browse/CB-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ