### PR TITLE
[CB-498] 지도 산책 저장 API 연결

### DIFF
--- a/src/pages/Daily/Walk/WalkRecordPage.tsx
+++ b/src/pages/Daily/Walk/WalkRecordPage.tsx
@@ -81,7 +81,7 @@ function useWalkRecord(isMapAvailable: boolean, location: LocationType) {
     }
   };
 
-  const openSaveModal = async () => {
+  const openSaveModal = () => {
     setSaveWalkModal(true);
   };
   const closeWalkModal = () => {
@@ -123,7 +123,7 @@ export default function WalkRecordMap() {
   const [confirm] = useConfirm();
   const platform = useAppSelector(getCurrentPlatform);
 
-  const isMapAvailable = platform === 'android' || platform === 'ios' || true;
+  const isMapAvailable = platform === 'android' || platform === 'ios';
   const currentDateString = searchParams.get('date');
 
   const { locationAvailable, data: location, isError: locationError } = useLocationWithApp();

--- a/src/pages/Daily/Walk/WalkRecordPage.tsx
+++ b/src/pages/Daily/Walk/WalkRecordPage.tsx
@@ -26,6 +26,8 @@ function useWalkRecord(isMapAvailable: boolean, location: LocationType) {
   const openToast = useToastMessage();
   const { data: currentPet } = useCurrentPet();
 
+  const dateString = searchParams.get('date');
+
   const [saveWalkModal, setSaveWalkModal] = useState(false);
 
   const [saveWalk, { isSuccess, isError }] = useCreateWalkMutation();
@@ -46,15 +48,15 @@ function useWalkRecord(isMapAvailable: boolean, location: LocationType) {
   const goWalkHistoryPage = () => navigate(`/daily/walk?date=${searchParams.get('date')}`);
 
   const saveWalkRecord = () => {
-    if (!currentPet?.id || !recordStartTime || !recordEndTime) {
+    if (!currentPet?.id || !recordStartTime || !recordEndTime || !dateString) {
       return;
     }
+
     const saveParams = {
       petId: currentPet.id,
-      date: searchParams.get('date'),
+      date: dateString,
       ...walkSaveData,
     };
-    console.log('saveWalk', saveParams);
     saveWalk(saveParams);
   };
 

--- a/src/pages/Daily/Walk/WalkRecordPage.tsx
+++ b/src/pages/Daily/Walk/WalkRecordPage.tsx
@@ -4,10 +4,13 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import Layout from '@/components/layout/Layout';
-import { useConfirm, useCounter, useKakaoMap, useToastMessage } from '@/utils/hooks';
+import { useConfirm, useCounter, useCurrentPet, useKakaoMap, useToastMessage } from '@/utils/hooks';
 import { useAppSelector } from '@/store/config';
 import { getCurrentPlatform } from '@/store/slices/platformSlice';
-import { getDateString } from '@/utils/libs/date';
+import { useCreateWalkMutation } from '@/store/api/dailyApi';
+import { getDateString, getTimeString } from '@/utils/libs/date';
+import { LocationType } from '@/@type/location';
+import { WalkRecordType } from '@/@type/walk';
 
 import { CurrentPosButton, KakaoMap } from './components/WalkRecordMap';
 import RecordToolbar from './components/WalkRecordToolbar';
@@ -16,48 +19,43 @@ import useLocationWithApp from './hooks/useLocationInApp';
 import SaveWalkModal from './components/SaveWalkRecordModal';
 import useLocationDistance from './hooks/useDistanceWithLocation';
 
-export default function WalkRecordMap() {
+function useWalkRecord(isMapAvailable: boolean, location: LocationType) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [confirm] = useConfirm();
   const openToast = useToastMessage();
-  const platform = useAppSelector(getCurrentPlatform);
-  const isMapAvailable = platform === 'android' || platform === 'ios';
+  const { data: currentPet } = useCurrentPet();
 
-  const { status, totalCount, start, pause, reset } = useCounter();
-  const { locationAvailable, data: location, isError: locationError } = useLocationWithApp();
+  const [saveWalkModal, setSaveWalkModal] = useState(false);
+
+  const [saveWalk, { isSuccess, isError }] = useCreateWalkMutation();
+  const { status, totalCount, start, pause, reset, recordStartTime, recordEndTime } = useCounter();
+
   const { distance, resetDistance, locationRecords } = useLocationDistance({
     location,
     isRunning: status === 'running',
   });
-  const { latitude, longitude } = location;
-  const { mapRef, moveToCurrentPosition } = useKakaoMap(latitude, longitude);
 
-  const [saveWalkModal, setSaveWalkModal] = useState(false);
-
-  const currentDateString = searchParams.get('date');
+  const walkSaveData: WalkRecordType = {
+    distance,
+    finishedAt: getTimeString(recordEndTime ?? new Date()),
+    startedAt: getTimeString(recordStartTime ?? new Date()),
+    totalTime: Math.ceil(totalCount / 60),
+  };
 
   const goWalkHistoryPage = () => navigate(`/daily/walk?date=${searchParams.get('date')}`);
-  const goBackGuard = async () => {
-    if (!isMapAvailable) {
-      goWalkHistoryPage();
+
+  const saveWalkRecord = () => {
+    if (!currentPet?.id || !recordStartTime || !recordEndTime) {
       return;
     }
-    const goBackConfirmed = await confirm({
-      contents: <p className="py-10">페이지를 나가시면 기록이 삭제됩니다.</p>,
-    });
-    if (!goBackConfirmed) return;
-
-    goWalkHistoryPage();
-  };
-
-  const openSaveModal = async () => {
-    setSaveWalkModal(true);
-  };
-  const saveWalkRecord = () => {
-    setSaveWalkModal(false);
-    openToast('산책 기록을 성공적으로 저장했습니다.', 'success');
-    goWalkHistoryPage();
+    const saveParams = {
+      petId: currentPet.id,
+      date: searchParams.get('date'),
+      ...walkSaveData,
+    };
+    console.log('saveWalk', saveParams);
+    saveWalk(saveParams);
   };
 
   const resetRecordState = async () => {
@@ -79,6 +77,82 @@ export default function WalkRecordMap() {
     } else {
       start();
     }
+  };
+
+  const openSaveModal = async () => {
+    setSaveWalkModal(true);
+  };
+  const closeWalkModal = () => {
+    setSaveWalkModal(false);
+  };
+
+  useEffect(() => {
+    if (!isSuccess) {
+      return;
+    }
+    openToast('산책이 저장되었습니다.', 'success');
+    goWalkHistoryPage();
+  }, [isSuccess]);
+
+  useEffect(() => {
+    if (!isError) {
+      return;
+    }
+    openToast('저장에 실패하였습니다.');
+  }, [isError]);
+
+  return {
+    status,
+    distance,
+    totalCount,
+    startRecord,
+    resetRecordState,
+    saveWalkRecord,
+    locationRecords,
+    saveWalkModal,
+    openSaveModal,
+    closeWalkModal,
+    walkSaveData,
+  };
+}
+export default function WalkRecordMap() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [confirm] = useConfirm();
+  const platform = useAppSelector(getCurrentPlatform);
+
+  const isMapAvailable = platform === 'android' || platform === 'ios' || true;
+  const currentDateString = searchParams.get('date');
+
+  const { locationAvailable, data: location, isError: locationError } = useLocationWithApp();
+  const { mapRef, moveToCurrentPosition } = useKakaoMap(location.latitude, location.longitude);
+  const {
+    status,
+    distance,
+    totalCount,
+    startRecord,
+    resetRecordState,
+    saveWalkRecord,
+    locationRecords,
+    saveWalkModal,
+    openSaveModal,
+    closeWalkModal,
+    walkSaveData,
+  } = useWalkRecord(isMapAvailable, location);
+
+  const goWalkHistoryPage = () => navigate(`/daily/walk?date=${searchParams.get('date')}`);
+
+  const goBackGuard = async () => {
+    if (!isMapAvailable) {
+      goWalkHistoryPage();
+      return;
+    }
+    const goBackConfirmed = await confirm({
+      contents: <p className="py-10">페이지를 나가시면 기록이 삭제됩니다.</p>,
+    });
+    if (!goBackConfirmed) return;
+
+    goWalkHistoryPage();
   };
 
   useEffect(() => {
@@ -113,7 +187,7 @@ export default function WalkRecordMap() {
         <div className="h-full w-full relative">
           <CurrentPosButton moveToCurrentPosition={moveToCurrentPosition} />
           {isMapAvailable && locationAvailable ? (
-            <KakaoMap ref={mapRef} latitude={latitude} longitude={longitude} />
+            <KakaoMap ref={mapRef} latitude={location.latitude} longitude={location.longitude} />
           ) : (
             <div className="bg-white w-full h-full flex flex-col items-center justify-center">
               <h4 className="text-lg ">지도를 이용할 수 없습니다</h4>
@@ -144,7 +218,7 @@ export default function WalkRecordMap() {
         />
       </div>
       {saveWalkModal && (
-        <SaveWalkModal close={() => setSaveWalkModal(false)} save={saveWalkRecord} />
+        <SaveWalkModal close={closeWalkModal} save={saveWalkRecord} walkData={walkSaveData} />
       )}
     </Layout>
   );

--- a/src/pages/Daily/Walk/components/SaveWalkRecordModal.tsx
+++ b/src/pages/Daily/Walk/components/SaveWalkRecordModal.tsx
@@ -1,24 +1,20 @@
 import { WalkRecordType } from '@/@type/walk';
 import Button from '@/components/Button';
 import Header from '@/components/layout/Header';
+
 import WalkRecordDetail from './WalkRecordDetail';
 
-const mockSaveWalkData: WalkRecordType = {
-  startedAt: '15:48',
-  finishedAt: '16:12',
-  totalTime: 24,
-  distance: 1.1,
-};
 type SaveWalkModalProps = {
   close: () => void;
   save: () => void;
+  walkData: WalkRecordType;
 };
-export default function SaveWalkModal({ close, save }: SaveWalkModalProps) {
+export default function SaveWalkModal({ close, save, walkData }: SaveWalkModalProps) {
   return (
     <div className="fixed top-0 w-full max-w-[425px] h-full bg-white z-[9999] pt-[50px] pb-[80px]">
       <Header canGoBack onClickGoBack={close} title="산책저장" />
       <div className=" bg-white w-full h-full max-w-[425px] p-4">
-        <WalkRecordDetail walkRecord={mockSaveWalkData} />
+        <WalkRecordDetail walkRecord={walkData} />
       </div>
       <div className="w-full flex p-4 items-center justify-around">
         <Button width="full" label="저장하기" onClick={save} />

--- a/src/store/api/dailyApi.ts
+++ b/src/store/api/dailyApi.ts
@@ -56,6 +56,13 @@ export type BasicRecordRequestType = {
 export type RecordRequestType = BasicRecordRequestType & {
   sessionId: number; // for disable cache behavior of RTK Query
 };
+
+type WalkRecordSaveParamsType = BasicRecordRequestType & {
+  distance: number;
+  totalTime: number;
+  startedAt?: string;
+  finishedAt?: string;
+};
 type NoteRequestType = RecordRequestType & {
   noteData: {
     images: File[];
@@ -221,7 +228,7 @@ export const dailyApiSlice = apiSlice.injectEndpoints({
         { type: 'DailyWalk', id: args },
       ],
     }),
-    createWalk: builder.mutation<any, any>({
+    createWalk: builder.mutation<any, WalkRecordSaveParamsType>({
       query: ({ petId, date, distance, totalTime, startedAt, finishedAt }) => {
         // startedAt, finishedAt이 있으면 totalTime 무시. 자동 계산
         // startedAt, finishedAt이 없으면 totalTime 필요. 필수
@@ -233,8 +240,9 @@ export const dailyApiSlice = apiSlice.injectEndpoints({
           formData.set('finishedAt', finishedAt); // hh:mm:ss
         }
         formData.set('date', date);
-        formData.set('distance', distance);
-        formData.set('totalTime', totalTime);
+        formData.set('distance', String(distance));
+        formData.set('totalTime', String(totalTime));
+
         return {
           url: `/v1/walks/pets/${petId}`,
           method: 'POST',

--- a/src/utils/hooks/useCounter.tsx
+++ b/src/utils/hooks/useCounter.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 
 export default function useCounter() {
   const [recordStartTime, setStartTime] = useState<Date | null>(null);
+  const [recordEndTime, setEndTime] = useState<Date | null>(null);
   const [status, setStatus] = useState<'reset' | 'running' | 'paused'>('reset');
   const [totalCount, setTotalCount] = useState(0);
   const timerId = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -24,6 +25,7 @@ export default function useCounter() {
     if (timerId.current === null) return;
     clearInterval(timerId.current);
     setStatus('paused');
+    setEndTime(new Date());
   };
 
   useEffect(() => {
@@ -41,5 +43,6 @@ export default function useCounter() {
     pause,
     reset,
     recordStartTime,
+    recordEndTime,
   };
 }

--- a/src/utils/libs/date.ts
+++ b/src/utils/libs/date.ts
@@ -12,3 +12,4 @@ export const getDateDiff = (targetDate: string, diffTarget: 'year' | 'month' | '
 
 export const getTotalMonthWithYearAndMonth = (year: number, month: number) => year * 12 + month;
 export const getDateString = (date: Date) => dayjs(date).format('YYYY-MM-DD');
+export const getTimeString = (date: Date) => dayjs(date).format('HH:mm');


### PR DESCRIPTION
[CB-498]

### 🔨 Jira 태스크

- [CB-505] 산책 기록 저장 API 연결 

### 📐 구현한 내용

- 지도를 이용한 산책 기록을 저장하기 위한 API를 추가하였습니다.

### 🚧 논의 사항

- 카카오 맵을 캡쳐하여 이미지로 사용하면 안된다고 합니다. 저장 시에 좌표 리스트를 저장할 필요가 있을 것 같습니다. 


[CB-498]: https://cocobob.atlassian.net/browse/CB-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-505]: https://cocobob.atlassian.net/browse/CB-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ