### PR TITLE
[CB-523] 반려동물 등록 페이지 수정

### DIFF
--- a/src/components/BottomSheet/BreedBottomSheet.tsx
+++ b/src/components/BottomSheet/BreedBottomSheet.tsx
@@ -6,7 +6,7 @@ import { concatClasses } from '@/utils/libs/concatClasses';
 import { DotLoader } from '@/Animation';
 import { InputStyle } from '../Form/FormInput';
 import BottomSheet from './BottomSheet';
-import Button from '../Button';
+import { Button } from '../Button';
 import {
   BottomSheetContentWrapper,
   BreedListContainer,
@@ -24,7 +24,7 @@ const BreedList = ({ breeds, selectedBreed, setBreed }: IBreedList) => (
       <div key={breed.id} onClick={() => setBreed(breed)}>
         <p
           className={concatClasses(
-            selectedBreed?.id === breed.id ? 'bg-blue-50' : '',
+            selectedBreed?.id === breed.id ? 'bg-primary-brightest' : '',
             'px-2 py-2 cursor-pointer',
           )}
         >
@@ -87,7 +87,7 @@ export default function BreedBottomSheet({
             }
           </BreedListContainer>
         )}
-        <Button label="선택" onClick={onClickSelectButton} />
+        <Button label="선택" primary="first" onClick={onClickSelectButton} />
       </BottomSheetContentWrapper>
     </BottomSheet>
   );

--- a/src/components/Button/index.style.ts
+++ b/src/components/Button/index.style.ts
@@ -1,5 +1,5 @@
 export const common = `
-max-w-sm
+max-w-full
 py-2
 px-10
 text-h3
@@ -8,6 +8,10 @@ font-bold
 rounded
 h-btn
 
+disabled:animate-none
+disabled:bg-gray
+disabled:opacity-50
+disabled:bg-none
 hover:animate-push
 active:animate-afterpush
 `;

--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -1,0 +1,33 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Button } from './index';
+
+const onClickMock = jest.fn();
+
+test('disabled true일 때, 버튼 비활성화 및 onClick 호출 X', () => {
+  const properties = {
+    label: '테스트 버튼',
+    disabled: true,
+    onClick: onClickMock,
+  };
+  render(<Button {...properties} />);
+  const renderedButton = screen.getByRole('button');
+
+  expect(renderedButton).toBeDisabled();
+  fireEvent.click(renderedButton);
+  expect(onClickMock).not.toBeCalled();
+});
+
+test('disabled false일 때, 버튼 활성화 및 onClick 호출 O', () => {
+  const properties = {
+    label: '테스트 버튼',
+    disabled: false,
+    onClick: onClickMock,
+  };
+  render(<Button {...properties} />);
+  const renderedButton = screen.getByRole('button');
+
+  expect(renderedButton).not.toBeDisabled();
+  fireEvent.click(renderedButton);
+  expect(onClickMock).toBeCalled();
+});

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -28,7 +28,7 @@ type ButtonPropsWithDefaultProps = DetailedHTMLProps<
 export const Button = (props: ButtonPropsWithDefaultProps) => {
   const {
     width = 'small',
-    primary,
+    primary = 'first',
     backgroundColor,
     label,
     className,

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,5 +1,5 @@
 import { concatClasses } from '@/utils/libs/concatClasses';
-import { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
+import { ButtonHTMLAttributes, DetailedHTMLProps, ReactElement } from 'react';
 import {
   common,
   FirstStyle,
@@ -13,8 +13,8 @@ interface ButtonProps {
   primary?: 'first' | 'second' | 'third' | 'fourth' | 'etc';
   backgroundColor?: string;
   width?: 'full' | 'small';
-  label: string;
-  onClick?: () => void;
+  label: string | ReactElement;
+  onClick?: () => void | Function;
   className?: string;
   disabled?: boolean;
 }
@@ -25,16 +25,18 @@ type ButtonPropsWithDefaultProps = DetailedHTMLProps<
 > &
   ButtonProps;
 
-export const Button = ({
-  width = 'small',
-  primary = 'first',
-  backgroundColor,
-  label,
-  className,
-  disabled,
-  type,
-  ...props
-}: ButtonPropsWithDefaultProps) => {
+export const Button = (props: ButtonPropsWithDefaultProps) => {
+  const {
+    width = 'small',
+    primary,
+    backgroundColor,
+    label,
+    className,
+    disabled,
+    type,
+    onClick,
+  } = props;
+
   const volume = width === 'full' ? 'min-w-full' : 'min-w-sm';
   const totalStyle = [`${volume} ${common}`];
   if (primary === 'first') totalStyle.push(FirstStyle);
@@ -46,6 +48,7 @@ export const Button = ({
   return (
     <button
       {...props}
+      onClick={onClick}
       className={concatClasses(totalStyle.join(' '), className ?? '')}
       disabled={disabled}
       style={{ backgroundColor }}

--- a/src/components/Form/FormButton.tsx
+++ b/src/components/Form/FormButton.tsx
@@ -1,5 +1,5 @@
 import { useCallback, ReactElement } from 'react';
-import styled from 'styled-components';
+import { common, FirstStyle } from '@/components/Button/index.style';
 
 interface ButtonProps {
   name: string | ReactElement;
@@ -9,36 +9,19 @@ interface ButtonProps {
   className?: string;
 }
 
-const FormButtonContainer = styled.button<{ disabled: boolean }>`
-  background: var(--primary-main);
-  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
-  border: none;
-  border-radius: 8px;
-  padding: 0.5rem;
-  width: 100%;
-
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: #fefefe;
-
-  &:hover {
-    animation: push 0.2s ease-out forwards;
-  }
-
-  &:active {
-    opacity: 0.8;
-    animation: afterpush 0.2s ease-out forwards;
-  }
-`;
 export default function FormButton(props: ButtonProps) {
   const { name, disabled, onClick, className } = props;
 
   const onClickButton = useCallback(() => !disabled && onClick && onClick(), [onClick]);
 
+  const total = [common, FirstStyle];
+
+  if (className) total.push(className);
+  total.push(`min-w-full`);
+
   return (
-    <FormButtonContainer className={className} onClick={onClickButton} disabled={disabled ?? false}>
+    <button onClick={onClickButton} className={total.join(' ')} disabled={disabled ?? false}>
       {name}
-    </FormButtonContainer>
+    </button>
   );
 }

--- a/src/components/Form/FormInput.test.tsx
+++ b/src/components/Form/FormInput.test.tsx
@@ -19,7 +19,7 @@ test('Error가 없을 때 UI 테스트', () => {
   );
   const inputEl = screen.getByLabelText('테스트 인풋');
 
-  expect(inputEl).toHaveStyle('border: 1px solid #EDEDED');
+  expect(inputEl).toHaveStyle('border: 1px solid #bbbbbb');
 });
 
 test('Error일 때 UI 테스트', () => {

--- a/src/components/Form/FormInput.tsx
+++ b/src/components/Form/FormInput.tsx
@@ -14,6 +14,7 @@ interface InputProps {
   errorMessage?: string;
   unit?: string;
   disabled?: boolean;
+  typing?: boolean;
 }
 
 const InputContainer = styled.div`
@@ -46,7 +47,7 @@ export const InputStyle = styled.input<{ isError: boolean | undefined; unit?: bo
   padding: 0 0.5rem;
   padding-right: ${({ unit }) => (unit ? '3rem' : '0.5rem')};
   background: white;
-  border: 1px solid ${({ isError, theme: { colors } }) => (isError ? colors.error : '#EDEDED')};
+  border: 1px solid ${({ isError, theme: { colors } }) => (isError ? colors.error : '#bbbbbb')};
   border-radius: 10px;
   -webkit-border-radius: 10px;
   -moz-borader-radius: 10px;
@@ -62,7 +63,7 @@ export const InputStyle = styled.input<{ isError: boolean | undefined; unit?: bo
 `;
 
 const UnitText = tw.div`
-  font-light text-secondary-dark text-sm bg-primary-max h-[47px] rounded-r absolute right-0 top-0 flex items-center justify-center w-[3rem]
+  font-light border border-secondary-brightest text-sm h-[47px] rounded-r absolute right-0 top-0 flex items-center justify-center w-[3rem]
 `;
 
 export default function Input({
@@ -76,6 +77,7 @@ export default function Input({
   disabled,
   isError,
   errorMessage,
+  typing,
 }: InputProps) {
   const { setVh } = useVh();
   return (
@@ -96,7 +98,13 @@ export default function Input({
           disabled={disabled}
           onBlur={setVh}
         />
-        {!!unit && <UnitText>{unit}</UnitText>}
+        {!!unit && (
+          <UnitText
+            className={typing ? 'text-primary bg-primary-max' : 'text-secondary bg-secondary-max'}
+          >
+            {unit}
+          </UnitText>
+        )}
         {errorMessage && (
           <p aria-errormessage={errorMessage} className="text-bad text-caption pt-1">
             {errorMessage}

--- a/src/pages/Login/components/EmailLoginForm.tsx
+++ b/src/pages/Login/components/EmailLoginForm.tsx
@@ -46,11 +46,8 @@ export default function EmailLoginForm({
         rules={register('password', { required: true })}
         isError={!!errors.password}
       />
-      <FormButton
-        className={`hover:animate-push active:animate-afterpush`}
-        name={!isLoading ? '로그인' : <SmallSpinner />}
-        disabled={isLoading}
-      />
+
+      <FormButton name={!isLoading ? '로그인' : <SmallSpinner />} disabled={isLoading} />
     </LoginForm>
   );
 }

--- a/src/pages/RegisterPet/Step1.tsx
+++ b/src/pages/RegisterPet/Step1.tsx
@@ -14,6 +14,7 @@ export default function Step1({ goNextStep, enrollPetData, setEnrollData }: Step
     formState: { errors },
     setValue,
     watch,
+    trigger,
   } = useForm<Step1Form>();
 
   const isButtonDisabled = !watch('name');
@@ -37,18 +38,24 @@ export default function Step1({ goNextStep, enrollPetData, setEnrollData }: Step
         <Form onSubmit={handleSubmit(onSubmitForm)}>
           <FormInput
             label=""
+            type="text"
             name="pet-name"
+            errorMessage={errors.name?.message}
             placeholder="반려동물의 이름을 입력해주세요"
             rules={register('name', {
               required: '이름을 입력해주세요',
-              maxLength: 20,
+              maxLength: {
+                value: 20,
+                message: '너무 긴 이름 같아요!',
+              },
+              onChange: () => {
+                trigger('name');
+              },
             })}
-            type="text"
             isError={!!errors.name?.message}
-            errorMessage={errors.name?.message}
           />
           <ButtonWrapper>
-            <FormButton name="다음으로" disabled={isButtonDisabled} />
+            <FormButton name="다음으로" disabled={isButtonDisabled || !!errors.name?.message} />
           </ButtonWrapper>
         </Form>
       </div>

--- a/src/pages/RegisterPet/Step2.tsx
+++ b/src/pages/RegisterPet/Step2.tsx
@@ -49,7 +49,7 @@ export default function Step2({ goNextStep, enrollPetData, setEnrollData }: Step
               <img
                 alt=""
                 src={petImage}
-                className="bg-gray-200 h-[200px] w-[200px] rounded-full overflow-hidden"
+                className="bg-secondary-brightest h-[200px] w-[200px] rounded-full overflow-hidden"
               />
             </div>
             <input

--- a/src/pages/RegisterPet/Step3.tsx
+++ b/src/pages/RegisterPet/Step3.tsx
@@ -92,7 +92,7 @@ export default function Step3({ goNextStep, enrollPetData, setEnrollData }: Step
           </div>
         </div>
         <ButtonWrapper>
-          <FormButton name="다음으로" disabled={false} />
+          <FormButton name="다음으로" disabled={!breed} />
         </ButtonWrapper>
       </Form>
       <BreedBottomSheet

--- a/src/pages/RegisterPet/Step3.tsx
+++ b/src/pages/RegisterPet/Step3.tsx
@@ -1,17 +1,23 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { IBreeds } from '@/@type/pet';
 import FormButton from '@/components/Form/FormButton';
-import { InputStyle } from '@/components/Form/FormInput';
 import BreedBottomSheet from '@/components/BottomSheet/BreedBottomSheet';
 
 import { useGetBreedsQuery } from '@/store/api/petApi';
 import { favBreeds } from '@/utils/constants/enrollment';
 import { useToastMessage, useBottomSheet, useVh } from '@/utils/hooks';
 import { concatClasses } from '@/utils/libs/concatClasses';
+import {
+  Input,
+  ButtonWrapper,
+  Form,
+  PageContainer,
+  PetNameHighlight,
+  QuestionText,
+} from './index.style';
 
-import { ButtonWrapper, Form, PageContainer, PetNameHighlight, QuestionText } from './index.style';
 import { StepPageProps } from './type';
 
 export default function Step3({ goNextStep, enrollPetData, setEnrollData }: StepPageProps) {
@@ -58,11 +64,11 @@ export default function Step3({ goNextStep, enrollPetData, setEnrollData }: Step
       </div>
       <Form onSubmit={handleSubmit(onValidSubmit)}>
         <div className="flex flex-col gap-4">
-          <InputStyle
+          <Input
             isError={false}
-            className="text-gray-400 text-left p-2 border-b border-b-gray-400 cursor-pointer"
+            className={concatClasses('text-black text-left p-2 cursor-pointer')}
             onClick={openBottomSheet}
-            onChange={(e) => e.preventDefault()}
+            onChange={(e: React.FormEvent<HTMLInputElement>) => e.preventDefault()}
             value={breed?.name}
             placeholder={breed?.id ? breed.name : '품종을 검색해보세요'}
             onBlur={setVh}
@@ -72,10 +78,10 @@ export default function Step3({ goNextStep, enrollPetData, setEnrollData }: Step
             {favBreeds.map((breedChip: IBreeds) => (
               <span
                 className={concatClasses(
-                  'py-1 px-2 text-sm rounded-lg whitespace-nowrap cursor-pointer',
+                  'py-1 px-2 text-sm rounded whitespace-nowrap cursor-pointer',
                   breedChip.id === breed?.id
                     ? 'border border-primary bg-primary-max text-primary'
-                    : 'border',
+                    : 'border border-secondary-brightest text-gray',
                 )}
                 onClick={() => setBreed(breedChip)}
                 key={breedChip.id}

--- a/src/pages/RegisterPet/Step4.tsx
+++ b/src/pages/RegisterPet/Step4.tsx
@@ -139,7 +139,7 @@ export default function Step4({ goNextStep, enrollPetData, setEnrollData }: Step
           </div>
         </div>
         <ButtonWrapper>
-          <FormButton name="다음으로" disabled={false} />
+          <FormButton name="다음으로" disabled={!age.birthday && !age.months} />
         </ButtonWrapper>
       </Form>
       <BottomSheet isOpen={isBirthdayBottomSheetOpen}>

--- a/src/pages/RegisterPet/Step4.tsx
+++ b/src/pages/RegisterPet/Step4.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
-import Button from '@/components/Button';
+import { Button } from '@/components/Button';
 import DatePicker from '@/components/DatePicker';
 import FormButton from '@/components/Form/FormButton';
 import {
@@ -94,7 +94,8 @@ export default function Step4({ goNextStep, enrollPetData, setEnrollData }: Step
       months: enrollPetData.age,
     });
     if (enrollPetData.birthday) setSelectedMode('birthday');
-    else setSelectedMode('monthsAge');
+    else if (enrollPetData.age) setSelectedMode('monthsAge');
+    else setSelectedMode('');
     return () => {
       closeBottomSheet();
     };
@@ -102,38 +103,34 @@ export default function Step4({ goNextStep, enrollPetData, setEnrollData }: Step
 
   return (
     <PageContainer>
-      <div className="mb-2">
+      <div className="mb-6">
         <QuestionText>
           <PetNameHighlight>{enrollPetData.name}!</PetNameHighlight>
         </QuestionText>
         <QuestionText>귀여운 이름이네요. 나이는요?</QuestionText>
       </div>
       <Form onSubmit={handleSubmit(onValidSubmit)}>
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-1">
-            <button
-              className="text-left p-1.5 border border-primary rounded-md"
-              type="button"
+            <Button
+              label="생년월일을 알고 있어요"
+              primary={selectedMode === 'birthday' ? 'third' : 'fourth'}
               onClick={openBirthdayBottomSheet}
-            >
-              생년월일을 알고 있어요
-            </button>
+            />
             {selectedMode === 'birthday' && (
-              <div className="py-2 px-3 w-full bg-blue-50 rounded-md">
+              <div className="p-3 w-full bg-primary-max rounded">
                 <p>{getKoreanStringDateFromDate(age.birthday ?? '')}</p>
               </div>
             )}
           </div>
           <div className="flex flex-col gap-1">
-            <button
-              className="text-left p-1.5 border border-primary rounded-md"
-              type="button"
+            <Button
+              label="대략적인 나이만 알고 있어요"
+              primary={selectedMode === 'monthsAge' ? 'third' : 'fourth'}
               onClick={openMonthsAgeBottomSheet}
-            >
-              대략적인 나이만 알고 있어요
-            </button>
+            />
             {selectedMode === 'monthsAge' && age.months > 0 && (
-              <div className="py-2 px-3 w-full bg-blue-50 rounded-md">
+              <div className="p-3 w-full bg-primary-max rounded">
                 <p>
                   {Math.floor(age.months / 12)}년 {age.months % 12}개월
                 </p>

--- a/src/pages/RegisterPet/Step5.tsx
+++ b/src/pages/RegisterPet/Step5.tsx
@@ -144,6 +144,7 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
             errorMessage={errors.bodyWeight?.message}
             typing={Boolean(watch('bodyWeight'))}
             placeholder="몸무게를 입력해주세요"
+            isError={!!errors.bodyWeight?.message}
             rules={register('bodyWeight', {
               required: true,
               pattern: {
@@ -156,10 +157,8 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
               validate: {
                 maxLength: () => {
                   const { bodyWeight } = getValues();
-                  if (bodyWeight.length > 8) {
-                    setValue('bodyWeight', bodyWeight.substring(0, 8));
-                  }
-                  return bodyWeight.length < 9 || '8자리 이상 입력하실 수 없습니다.';
+
+                  return bodyWeight.toString().length < 9 || '8자리 이상 입력하실 수 없습니다.';
                 },
               },
             })}

--- a/src/pages/RegisterPet/Step5.tsx
+++ b/src/pages/RegisterPet/Step5.tsx
@@ -37,6 +37,8 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
     handleSubmit,
     setValue,
     watch,
+    trigger,
+    getValues,
     formState: { errors },
   } = useForm<Step4Form>();
 
@@ -138,16 +140,29 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
             label="몸무게"
             name="bodyWeight"
             unit="KG"
+            type="text"
+            errorMessage={errors.bodyWeight?.message}
+            typing={Boolean(watch('bodyWeight'))}
             placeholder="몸무게를 입력해주세요"
             rules={register('bodyWeight', {
               required: true,
-              valueAsNumber: true,
               pattern: {
-                value: /^(0|[1-9]\d*)(\.\d+)?$/,
-                message: '숫자를 입력해주세요',
+                value: /^[\d]*\.?[\d]{0,8}$/,
+                message: '숫자를 입력하세요.',
+              },
+              onChange: () => {
+                trigger('bodyWeight');
+              },
+              validate: {
+                maxLength: () => {
+                  const { bodyWeight } = getValues();
+                  if (bodyWeight.length > 8) {
+                    setValue('bodyWeight', bodyWeight.substring(0, 8));
+                  }
+                  return bodyWeight.length < 9 || '8자리 이상 입력하실 수 없습니다.';
+                },
               },
             })}
-            type="text"
           />
           <div className="flex flex-col gap-2">
             <p className="font-medium text-[14px]">활동수준</p>
@@ -158,7 +173,18 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
                   name="activity-level"
                   id="activity-level"
                   list="tickmarks"
-                  className="w-full h-1.5 rounded-lg bg-gray-200 appearance-none cursor-pointer dark:gray-600"
+                  className={concatClasses(
+                    'w-full h-1.5 rounded-lg appearance-none cursor-pointer',
+                    selectedActivityLevel === 1
+                      ? 'bg-secondary-brightest dark:secondary-dark'
+                      : selectedActivityLevel === 2
+                      ? 'bg-primary-brightest dark:primary-dark'
+                      : selectedActivityLevel === 3
+                      ? 'bg-primary-brighter dark:primary-darker'
+                      : selectedActivityLevel === 4
+                      ? 'bg-primary-bright dark:bg-primary-dark'
+                      : 'bg-primary dark:bg-primary',
+                  )}
                   min="1"
                   max="5"
                   value={selectedActivityLevel}

--- a/src/pages/RegisterPet/index.style.ts
+++ b/src/pages/RegisterPet/index.style.ts
@@ -1,5 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import tw from 'tailwind-styled-components';
+import { InputStyle } from '@/components/Form/FormInput';
 
 export const PageContainer = styled.div`
   display: flex;
@@ -15,18 +16,11 @@ export const QuestionWrapper = styled.div`
   justify-content: flex-start;
 `;
 
-export const QuestionText = styled.h3`
-  /* H3/H3 Bold */
-
-  font-family: 'Noto Sans KR';
-  font-style: normal;
-  font-weight: 700;
-  font-size: 20px;
-  line-height: 29px;
-  /* identical to box height, or 145% */
-
-  letter-spacing: -0.02em;
+export const QuestionText = tw.h3`
+  text-h3
+  font-bold
 `;
+
 export const SubQuestionText = styled.p`
   font-family: 'Noto Sans KR';
   font-style: normal;
@@ -40,6 +34,15 @@ export const SubQuestionText = styled.p`
 export const PetNameHighlight = tw.span`
   font-bold
   text-primary
+`;
+
+export const Input = styled(InputStyle)`
+  ${(props) =>
+    props.value &&
+    css`
+      border: 1px solid #1a70d2;
+      background-color: #f2f8ff;
+    `}
 `;
 
 export const ButtonWrapper = styled.div`
@@ -84,13 +87,12 @@ export const Form = tw(StyledForm)`
   flex-col
   justify-between
 `;
+
 export const SkipButton = tw.button`
-  font-gray-600;
-  decoration-gray-400
+  decoration-secondary-brighter
   underline
   underline-offset-4
   text-center
-  leading-[20px]
-  text-[14px]
-  text-caption
+  text-[0.8125rem]
+  text-gray
 `;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,50 +11,50 @@ module.exports = {
     maxWidth: {
       full: '425px',
     },
-    // font
-    fontSize: {
-      h1: [
-        '2rem',
-        {
-          lineHeight: '2.88rem',
-          letterSpacing: '-0.025em',
-          fontWeight: '700',
-        },
-      ],
-      h2: [
-        '1.5rem',
-        {
-          lineHeight: '2.16rem',
-          letterSpacing: '-0.025em',
-          fontWeight: '700',
-        },
-      ],
-      h3: [
-        '1.125rem',
-        {
-          lineHeight: '1.62rem',
-          letterSpacing: '-0.025em',
-          fontWeight: '500',
-        },
-      ],
-      p: [
-        '1rem',
-        {
-          lineHeight: '1.44rem',
-          letterSpacing: '-0.02em',
-          fontWeight: '400',
-        },
-      ],
-      caption: [
-        '0.8125rem',
-        {
-          lineHeight: '1.26rem',
-          letterSpacing: '-0.02em',
-          fontWeight: '300',
-        },
-      ],
-    },
     extend: {
+      // font
+      fontSize: {
+        h1: [
+          '2rem',
+          {
+            lineHeight: '2.88rem',
+            letterSpacing: '-0.025em',
+            fontWeight: '700',
+          },
+        ],
+        h2: [
+          '1.5rem',
+          {
+            lineHeight: '2.16rem',
+            letterSpacing: '-0.025em',
+            fontWeight: '700',
+          },
+        ],
+        h3: [
+          '1.125rem',
+          {
+            lineHeight: '1.62rem',
+            letterSpacing: '-0.025em',
+            fontWeight: '500',
+          },
+        ],
+        p: [
+          '1rem',
+          {
+            lineHeight: '1.44rem',
+            letterSpacing: '-0.02em',
+            fontWeight: '400',
+          },
+        ],
+        caption: [
+          '0.8125rem',
+          {
+            lineHeight: '1.26rem',
+            letterSpacing: '-0.02em',
+            fontWeight: '300',
+          },
+        ],
+      },
       // custon min-height
       minHeight: {
         btn: '2.9375rem',


### PR DESCRIPTION
[CB-523]

### 🔨 Jira 태스크

- [CB-533] 반려동물의 이름의 길이를 제한해야 함
- [CB-534] Tailwind에 맞게 스타일 수정해야 함

### 📐 구현한 내용

- `Tailwind.cofing`을 수정하면서 스타일이 잘못 적용되어 있던 **반려동물 등록 페이지**의 디자인을 잡았습니다.
- 디자인 수정과 동시에 몇 가지 사소한 **UX Flow**와 **에러 규칙**을 추가하였습니다.
   - 정보를 작성할 때 시선이 윗부분에 고정되고, 행동을 다 마치고 나면 버튼에 의해 다음 단계로 넘어가려고 합니다.
   - 이 때, 버튼이 활성화되어 있으면 사용자에게 혼돈을 줄 수가 있다고 생각해서 `disabled`에 따라 디자인을 다르게 하였습니다.
   - 또한, 이 때 모든 조건을 충족할 때만 활성화하게끔 하도록 유도하였습니다.
   - 에러 메세지는 이 단계예선 `Toast`보단 `react-hook-form`의 `errorMessage`를 이용하는 게 좋을 듯 합니다.

|페이지 1|페이지 3|
|---|---|
|![page1](https://user-images.githubusercontent.com/79848632/201132818-1175704a-5087-4c5d-8829-14206c4dd067.gif)|![page2](https://user-images.githubusercontent.com/79848632/201132972-e7d67225-7b31-40c3-b565-909d048dfd23.gif)|

|페이지 4|페이지 5|
|---|---|
![page3](https://user-images.githubusercontent.com/79848632/201132916-7f1f6ef0-1f8e-4f8f-b791-23908d60ea8b.gif)|![page4](https://user-images.githubusercontent.com/79848632/201132927-4365b31d-5f03-4d29-99aa-763887e215fb.gif)





|

### 🚧 논의 사항


- `Tailwind-styled-components`를 사용하면서 간혹 폰트 스타일이 먹지 않는 오류가 있습니다.
- 기본 Html 태그로 하면 정상 작동합니다!


![test1](https://user-images.githubusercontent.com/79848632/201134141-6de119e3-e29a-4fbe-bcee-d01e06d624fe.png)
![test2](https://user-images.githubusercontent.com/79848632/201134144-07d89fd9-29c6-42f9-96cb-debb31f31cb2.png)
![test3](https://user-images.githubusercontent.com/79848632/201134162-fecd14a1-ed60-496c-9713-745cb84cf642.png)


[CB-523]: https://cocobob.atlassian.net/browse/CB-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-533]: https://cocobob.atlassian.net/browse/CB-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-534]: https://cocobob.atlassian.net/browse/CB-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ