### PR TITLE
[CB-469] 노트 중복 버그 수정

### DIFF
--- a/src/pages/Daily/DailyPage.tsx
+++ b/src/pages/Daily/DailyPage.tsx
@@ -52,18 +52,10 @@ const overviewSwiperDefaultOptions: SwiperProps = {
 export default function DailyMain() {
   const currentPetId = useAppSelector(getCurrentPet);
 
-  if (!currentPetId)
-    return (
-      <Layout header title="데일리 기록" footer>
-        <div className="w-full h-full flex flex-col items-center justify-center">
-          <h3>반려동물을 등록 후 이용가능합니다</h3>
-        </div>
-      </Layout>
-    );
-
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const currentDateString = searchParams.get('date');
+
   useEffect(() => {
     if (currentDateString) {
       return;
@@ -71,22 +63,17 @@ export default function DailyMain() {
     navigate(`/daily?date=${getDateString(new Date())}`, { replace: true });
   }, [currentDateString]);
 
-  const isInvalidDate =
-    currentDateString && new Date(currentDateString).toString() === 'Invalid Date';
-  if (isInvalidDate) {
-    return <Navigate to="/404" replace />;
-  }
   const timestamp = useRef(Date.now()).current;
   const currentDate = currentDateString ? new Date(currentDateString) : new Date();
   const dateString = currentDateString ?? getDateString(new Date());
   const { recordIdList, setActiveStartDate } = useDailyRecordsOfMonth(
     currentPetId,
-    dateString,
     timestamp,
+    dateString,
   );
   const { numberOfOverviewItmes, recordOverview } = useDailyRecordOverview(
-    currentPetId,
     dateString,
+    currentPetId,
   );
   const { goHealthPage, selectWalkOrNote } = useRecordMenus(dateString);
 
@@ -100,6 +87,20 @@ export default function DailyMain() {
         : false,
   };
 
+  const isInvalidDate =
+    currentDateString && new Date(currentDateString).toString() === 'Invalid Date';
+
+  if (!currentPetId)
+    return (
+      <Layout header title="데일리 기록" footer>
+        <div className="w-full h-full flex flex-col items-center justify-center">
+          <h3>반려동물을 등록 후 이용가능합니다</h3>
+        </div>
+      </Layout>
+    );
+  if (isInvalidDate) {
+    return <Navigate to="/404" replace />;
+  }
   return (
     <Layout header footer title="데일리 기록">
       <div className="p-4 flex flex-col items-center gap-4 w-full h-full overflow-y-auto space-y-4">

--- a/src/pages/Daily/Note/NoteWritePage.tsx
+++ b/src/pages/Daily/Note/NoteWritePage.tsx
@@ -9,7 +9,12 @@ import { ReactComponent as PlusIcon } from '@/assets/icon/plus_icon.svg';
 import { useConfirm, useToastMessage } from '@/utils/hooks';
 
 import Button from '@/components/Button';
-import { NoteType, useCreateNoteRecordMutation, useEditNoteMutation } from '@/store/api/dailyApi';
+import {
+  NoteType,
+  useCreateNoteRecordMutation,
+  useEditNoteMutation,
+  useGetDailyRecordOverviewQuery,
+} from '@/store/api/dailyApi';
 import { useAppSelector } from '@/store/config';
 import { getCurrentPet } from '@/store/slices/userSlice';
 import {
@@ -65,7 +70,12 @@ export default function NoteAddPage() {
   const [currentImages, setCurrentImages] = useState<{ imageId: number; path: string }[]>([]);
   const [removeImageIds, setRemoveImageIds] = useState<number[]>([]);
   const canAddImage = images.length < 4;
-
+  const { data: dailyOverview } = useGetDailyRecordOverviewQuery(
+    { date: currentDate, petId: Number(currentPetId) },
+    {
+      skip: Number.isNaN(currentPetId),
+    },
+  );
   const [createNoteMutation, { isLoading: isCreateLoading, isSuccess }] =
     useCreateNoteRecordMutation();
   const [editNoteMutation, { isLoading: isUpdateLoading, isSuccess: isUpdateSuccess }] =
@@ -75,6 +85,11 @@ export default function NoteAddPage() {
 
   const createNote = (formInputs: NoteFormType) => {
     if (!currentPetId) {
+      return;
+    }
+    if (dailyOverview?.dailyId) {
+      openToast('하루에 한 개의 글만 작성할 수 있습니다');
+      navigate(`/daily`);
       return;
     }
     const noteData = {

--- a/src/pages/Daily/hooks/useDailyRecordOverview.tsx
+++ b/src/pages/Daily/hooks/useDailyRecordOverview.tsx
@@ -4,15 +4,20 @@ import dayjs from 'dayjs';
 import { useToastMessage } from '@/utils/hooks';
 import { useGetDailyRecordOverviewQuery } from '@/store/api/dailyApi';
 
-const useDailyRecordOverview = (currentPetId: number, currentDateString: string) => {
+const useDailyRecordOverview = (currentDateString: string, currentPetId: number | null) => {
   const openToast = useToastMessage();
   const currentDate = new Date(currentDateString);
   const [idCount, setIdCount] = useState(0);
 
-  const { data, isLoading, isError } = useGetDailyRecordOverviewQuery({
-    date: dayjs(currentDate).format('YYYY-MM-DD'),
-    petId: currentPetId,
-  });
+  const { data, isLoading, isError } = useGetDailyRecordOverviewQuery(
+    {
+      date: dayjs(currentDate).format('YYYY-MM-DD'),
+      petId: Number(currentPetId),
+    },
+    {
+      skip: !currentPetId || Number.isNaN(Number(currentPetId)),
+    },
+  );
 
   useEffect(() => {
     setIdCount(0);

--- a/src/pages/Daily/hooks/useDailyRecordsOfMonth.tsx
+++ b/src/pages/Daily/hooks/useDailyRecordsOfMonth.tsx
@@ -7,23 +7,28 @@ import { getDateString } from '@/utils/libs/date';
 import { useGetDailyRecordIdListOfMonthQuery } from '@/store/api/dailyApi';
 
 const useDailyRecordsOfMonth = (
-  currentPetId: number,
-  currentDateString: string,
-  timestamp = Date.now(),
+  currentPetId: number | null,
+  timestamp: number,
+  currentDateString?: string,
 ) => {
   const openToast = useToastMessage();
   const navigate = useNavigate();
 
-  const currentDate = new Date(currentDateString);
-
-  const [activeStartDate, setActiveStartDate] = useState<Date>(currentDate);
+  const [activeStartDate, setActiveStartDate] = useState<Date>(
+    currentDateString ? new Date(currentDateString) : new Date(),
+  );
   const activeStartDateString = dayjs(activeStartDate).format('YYYY-MM');
 
-  const { data, isError, isLoading } = useGetDailyRecordIdListOfMonthQuery({
-    date: activeStartDateString,
-    petId: currentPetId,
-    sessionId: timestamp,
-  });
+  const { data, isError, isLoading } = useGetDailyRecordIdListOfMonthQuery(
+    {
+      date: activeStartDateString,
+      petId: Number(currentPetId),
+      sessionId: timestamp,
+    },
+    {
+      skip: !currentPetId || Number.isNaN(Number(currentPetId)),
+    },
+  );
 
   useEffect(() => {
     const _activeStartDateString = getDateString(new Date(activeStartDate));

--- a/src/pages/Daily/hooks/useRecordMenus.tsx
+++ b/src/pages/Daily/hooks/useRecordMenus.tsx
@@ -1,21 +1,35 @@
 import { useNavigate } from 'react-router-dom';
 
 import { useSelectModal } from '@/utils/hooks';
+import { useGetDailyRecordOverviewQuery } from '@/store/api/dailyApi';
+import { useAppSelector } from '@/store/config';
+import { getCurrentPet } from '@/store/slices/userSlice';
 
 const useRecordMenus = (currentDateString: string) => {
   const navigate = useNavigate();
   const [openSelectMenu] = useSelectModal();
+  const currentPetId = useAppSelector(getCurrentPet);
+  const { data: dailyOverview } = useGetDailyRecordOverviewQuery(
+    { date: currentDateString, petId: Number(currentPetId) },
+    {
+      skip: !currentPetId,
+    },
+  );
 
   const goHealthPage = () => navigate(`/daily/health?date=${currentDateString}`);
   const goRecordPage = (recordPageType: string) => {
     if (recordPageType === '산책일지') {
       navigate(`/daily/walk?date=${currentDateString}`);
     } else if (recordPageType === '반려일지') {
-      navigate(`/daily/note/new`, {
-        state: {
-          date: currentDateString,
-        },
-      });
+      if (dailyOverview?.dailyId) {
+        navigate(`/daily/note/${dailyOverview.dailyId}`);
+      } else {
+        navigate(`/daily/note/new`, {
+          state: {
+            date: currentDateString,
+          },
+        });
+      }
     }
   };
   const selectWalkOrNote = async () => {

--- a/src/store/api/dailyApi.ts
+++ b/src/store/api/dailyApi.ts
@@ -235,6 +235,7 @@ export const dailyApiSlice = apiSlice.injectEndpoints({
       },
       invalidatesTags: (result, api, args) => [
         'DailyRecord',
+        { type: 'Daily', id: args.date },
         { type: 'Daily', id: args.date.substring(0, 7) },
       ],
     }),


### PR DESCRIPTION
[CB-469]

### 🔨 Jira 태스크

- [CB-469] 동일 날짜에 반려일지 기록 생성이 두 번 이상 가능

### 📐 구현한 내용

- 노트 작성한 이력이 있다면 작성페이지가 아닌 상세페이지로 이동
- 비정상적인 경로로 작성페이지로 이동하더라고 작성이 되지 않도록 막음

![cb469pr](https://user-images.githubusercontent.com/2215762/202741718-8bc519fb-b159-4d79-9c97-b8bb40b269ca.gif)


### 🚧 논의 사항

-


[CB-469]: https://cocobob.atlassian.net/browse/CB-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-469]: https://cocobob.atlassian.net/browse/CB-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ