### PR TITLE
[CB-566] 반려동물 등록과 수정 페이지 동기화

### DIFF
--- a/src/components/ActivitySelector.tsx
+++ b/src/components/ActivitySelector.tsx
@@ -1,0 +1,75 @@
+import { ChangeEvent, useState } from 'react';
+
+import { concatClasses } from '@/utils/libs/concatClasses';
+
+const activityLevelStrings = [
+  '',
+  '활동이 적은 편이에요',
+  '다른 아이들보다 차분한 편이에요',
+  '잘 움직이는 편이에요',
+  '활발해요!',
+  '엄청 기운이 넘쳐요!',
+];
+
+const useSelectActivityLevel = (defaultLevel?: number) => {
+  const [selectedActivityLevel, setSelectedActivityLevel] = useState(defaultLevel ?? 3);
+
+  const handleSelectActivityLevel = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+    const level = parseInt(value, 10);
+    if (Number.isNaN(level) || level < 1 || level > 5) {
+      return;
+    }
+    setSelectedActivityLevel(level);
+  };
+
+  return {
+    selectedActivityLevel,
+    setSelectedActivityLevel,
+    handleSelectActivityLevel,
+  };
+};
+
+const barStyle = [
+  'bg-secondary-brightest dark:secondary-dark',
+  'bg-primary-brightest dark:primary-dark',
+  'bg-primary-brighter dark:primary-darker',
+  'bg-primary-bright dark:bg-primary-dark',
+  'bg-primary dark:bg-primary',
+];
+
+type ActivityLevelSelectorProps = {
+  activityLevel: number;
+  // eslint-disable-next-line
+  handleSelectLevel: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+const ActivityLevelSelector = ({
+  activityLevel,
+  handleSelectLevel,
+}: ActivityLevelSelectorProps) => {
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <input
+          type="range"
+          name="activity-level"
+          id="activity-level"
+          list="tickmarks"
+          className={concatClasses(
+            'w-full h-1.5 rounded-lg appearance-none cursor-pointer',
+            barStyle[activityLevel - 1],
+          )}
+          min="1"
+          max="5"
+          value={activityLevel}
+          onChange={handleSelectLevel}
+        />
+      </div>
+      <div>
+        <p className="text-primary-bright text-label">{activityLevelStrings[activityLevel]}</p>
+      </div>
+    </div>
+  );
+};
+
+export { useSelectActivityLevel };
+export default ActivityLevelSelector;

--- a/src/components/BottomSheet/BirthdayBottomSheet.tsx
+++ b/src/components/BottomSheet/BirthdayBottomSheet.tsx
@@ -1,13 +1,11 @@
-import { getDateDiff } from '@/utils/libs/date';
-import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import DatePicker from '@/components/DatePicker';
+import { getDateDiff, getDateString } from '@/utils/libs/date';
+
 import BottomSheet from './BottomSheet';
+import { BottomSheetContentWrapper, Title } from './BottomSheet.style';
 import Button from '../Button';
-import {
-  BottomSheetContentWrapper,
-  DatePicker,
-  SelectDateWrapper,
-  Title,
-} from './BottomSheet.style';
 
 interface BirthdayBottomSheetProps {
   isOpen: boolean;
@@ -20,7 +18,7 @@ export default function BirthdayBottomSheet({
   birthday,
   onSave,
 }: BirthdayBottomSheetProps) {
-  const [date, setDate] = useState(birthday);
+  const [date, setDate] = useState<string | undefined>(birthday);
 
   const ageString = useMemo(() => {
     if (!date) return '';
@@ -48,16 +46,21 @@ export default function BirthdayBottomSheet({
   return (
     <BottomSheet isOpen={isOpen}>
       <BottomSheetContentWrapper>
-        <Title>언제 태어났나요?</Title>
-        <SelectDateWrapper className="flex-col">
-          <DatePicker
-            type="date"
-            defaultValue={date}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setDate(e.target.value)}
-          />
-          {ageString && <p className="text-label text-primary">{`나이 : ${ageString}`}</p>}
-        </SelectDateWrapper>
-        <Button label="선택완료" onClick={saveDate} />
+        <div className="flex flex-col gap-1">
+          <Title>언제 태어났나요?</Title>
+          <div className="py-3 w-full flex flex-col items-center justify-center gap-3">
+            <DatePicker
+              currentDate={date ? new Date(date) : new Date()}
+              onChangeDate={(selectedDate) => {
+                if (selectedDate) {
+                  setDate(getDateString(selectedDate));
+                }
+              }}
+            />
+            {date && <p className="text-label text-primary">{`나이 : ${ageString}`}</p>}
+          </div>
+          <Button label="선택완료" onClick={saveDate} />
+        </div>
       </BottomSheetContentWrapper>
     </BottomSheet>
   );

--- a/src/pages/Mypage/pets/[id]/edit.tsx
+++ b/src/pages/Mypage/pets/[id]/edit.tsx
@@ -7,7 +7,7 @@ import Layout from '@/components/layout/Layout';
 import { FormInput, FormButton } from '@/components/Form';
 import { InputStyle, Label } from '@/components/Form/FormInput';
 
-import { ActivityLevelType, IBreeds, IPetInformation, PetSexType, PetInfoForm } from '@/@type/pet';
+import { IBreeds, IPetInformation, PetSexType, PetInfoForm } from '@/@type/pet';
 import { useGetPetsDetailQuery, useUpdatePetDataMutation } from '@/store/api/petApi';
 
 import { useSelectImage, useBottomSheet, useConfirm, useToastMessage } from '@/utils/hooks';
@@ -18,6 +18,7 @@ import {
   MonthsAgeBottomSheet,
 } from '@/components/BottomSheet';
 import useAgeBottomSheet from '@/components/BottomSheet/hooks/useAgeBottomSheet';
+import ActivityLevelSelector, { useSelectActivityLevel } from '@/components/ActivitySelector';
 
 import { ReactComponent as TrashIcon } from '@/assets/icon/trash_icon.svg';
 import { ReactComponent as EditIcon } from '@/assets/icon/edit_icon.svg';
@@ -46,7 +47,6 @@ interface IPetEditForm {
   isSpayed: boolean;
   isPregnant: boolean;
 }
-const activityLevels: ActivityLevelType[] = [1, 2, 3, 4, 5];
 
 function useUpdatePet() {
   const navigate = useNavigate();
@@ -103,7 +103,8 @@ export default function EditPet() {
     openBirthdayBottomSheet,
   } = useAgeBottomSheet({ petAge: petData?.age ?? 0, petBirthday: petData?.birthday ?? '' });
 
-  const [selectedActivityLevel, setSelectedActivityLevel] = useState<ActivityLevelType>(3);
+  const { selectedActivityLevel, setSelectedActivityLevel, handleSelectActivityLevel } =
+    useSelectActivityLevel();
   const [breed, setBreed] = useState<IBreeds | undefined>();
   const [isImageDeleted, setIsImageDeleted] = useState(false); // 사진을 삭제했을 때 true, 변경하거나 그대로 유지 : false
 
@@ -323,19 +324,10 @@ export default function EditPet() {
                   </div>
                   <FlexColumn className="gap-2">
                     <p>활동수준</p>
-                    <div className="flex gap-4">
-                      {activityLevels.map((value) => (
-                        <input
-                          key={value}
-                          type="radio"
-                          name={String(value)}
-                          id={`activity-level-${value}`}
-                          value={value}
-                          checked={value === selectedActivityLevel}
-                          onChange={() => setSelectedActivityLevel(value)}
-                        />
-                      ))}
-                    </div>
+                    <ActivityLevelSelector
+                      activityLevel={selectedActivityLevel}
+                      handleSelectLevel={handleSelectActivityLevel}
+                    />
                   </FlexColumn>
                 </FlexColumn>
               </div>

--- a/src/pages/RegisterPet/Step4.tsx
+++ b/src/pages/RegisterPet/Step4.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
+
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import { Button } from '@/components/Button';
 import DatePicker from '@/components/DatePicker';
@@ -11,6 +12,7 @@ import {
   getDateString,
 } from '@/utils/libs/date';
 import { useBottomSheet, useToastMessage } from '@/utils/hooks';
+
 import { ButtonWrapper, PageContainer, QuestionText, Form, PetNameHighlight } from './index.style';
 import { StepPageProps } from './type';
 

--- a/src/pages/RegisterPet/Step5.tsx
+++ b/src/pages/RegisterPet/Step5.tsx
@@ -1,7 +1,9 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { ActivityLevelType, PetSexType } from '@/@type/pet';
+
+import { PetSexType } from '@/@type/pet';
 import { FormInput, FormButton } from '@/components/Form';
+import ActivityLevelSelector, { useSelectActivityLevel } from '@/components/ActivitySelector';
 import { concatClasses } from '@/utils/libs/concatClasses';
 import { ReactComponent as MaleIcon } from '@/assets/icon/male_icon.svg';
 import { ReactComponent as FemaleIcon } from '@/assets/icon/female_icon.svg';
@@ -23,14 +25,6 @@ interface Step4Form {
   bodyWeight: number;
 }
 
-const activityLevelStrings = [
-  '',
-  '활동이 적은 편이에요',
-  '다른 아이들보다 차분한 편이에요',
-  '잘 움직이는 편이에요',
-  '활발해요!',
-  '엄청 기운이 넘쳐요!',
-];
 export default function Step5({ goNextStep, enrollPetData, setEnrollData }: StepPageProps) {
   const {
     register,
@@ -42,7 +36,7 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
     formState: { errors },
   } = useForm<Step4Form>();
 
-  const [selectedActivityLevel, setSelectedActivityLevel] = useState(
+  const { selectedActivityLevel, handleSelectActivityLevel } = useSelectActivityLevel(
     enrollPetData?.activityLevel ?? 3,
   );
 
@@ -67,14 +61,6 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
       setValue('bodyWeight', enrollPetData.bodyWeight);
     }
   }, [enrollPetData]);
-
-  const handleSelectActivityLevel = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
-    const level = parseInt(value, 10);
-    if (Number.isNaN(level) || level < 1 || level > 5) {
-      return;
-    }
-    setSelectedActivityLevel(level as ActivityLevelType);
-  };
 
   return (
     <PageContainer>
@@ -165,37 +151,10 @@ export default function Step5({ goNextStep, enrollPetData, setEnrollData }: Step
           />
           <div className="flex flex-col gap-2">
             <p className="font-medium text-label">활동수준</p>
-            <div className="flex flex-col gap-3">
-              <div>
-                <input
-                  type="range"
-                  name="activity-level"
-                  id="activity-level"
-                  list="tickmarks"
-                  className={concatClasses(
-                    'w-full h-1.5 rounded-lg appearance-none cursor-pointer',
-                    selectedActivityLevel === 1
-                      ? 'bg-secondary-brightest dark:secondary-dark'
-                      : selectedActivityLevel === 2
-                      ? 'bg-primary-brightest dark:primary-dark'
-                      : selectedActivityLevel === 3
-                      ? 'bg-primary-brighter dark:primary-darker'
-                      : selectedActivityLevel === 4
-                      ? 'bg-primary-bright dark:bg-primary-dark'
-                      : 'bg-primary dark:bg-primary',
-                  )}
-                  min="1"
-                  max="5"
-                  value={selectedActivityLevel}
-                  onChange={handleSelectActivityLevel}
-                />
-              </div>
-              <div>
-                <p className="text-primary-bright text-label">
-                  {activityLevelStrings[selectedActivityLevel]}
-                </p>
-              </div>
-            </div>
+            <ActivityLevelSelector
+              activityLevel={selectedActivityLevel}
+              handleSelectLevel={handleSelectActivityLevel}
+            />
           </div>
 
           <div>


### PR DESCRIPTION
[CB-566]

### 🔨 Jira 태스크

- [CB-567] 생일 선택 BottomSheet 적용
- [CB-568] 활동 수준 선택 적용

### 📐 구현한 내용

- 생일 선택 BoittomSheet이 등록 부분에는 적용이 되어있었지만, 수정 페이지에는 예전 버전으로 적용되어있었습니다. 등록 페이지와 동일하게 작동하도록 수정하였습니다.
  <img src='https://user-images.githubusercontent.com/2215762/204263450-c5633094-1890-401f-873e-32527e042d75.png' width='250'/>
- 활동 수준 선택하는 부분이 등록 페이지에는 새로운 버전으로 적용되어있었지만, 수정 페이지는 예전 버전이었습니다. 새로운 버전으로 적용하였습니다.
  <img src='https://user-images.githubusercontent.com/2215762/204263301-563051b2-da09-4757-8ee2-892673b143ed.png' width='250'/>


### 🚧 논의 사항



[CB-566]: https://cocobob.atlassian.net/browse/CB-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-567]: https://cocobob.atlassian.net/browse/CB-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-568]: https://cocobob.atlassian.net/browse/CB-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ